### PR TITLE
Missing ogg file

### DIFF
--- a/src/engine/audio.c
+++ b/src/engine/audio.c
@@ -130,7 +130,7 @@ internal void AUDIO_allocate(WrenVM* vm) {
   } else if (strstr(data->name, ".ogg") != NULL) {
     data->audioType = AUDIO_TYPE_OGG;
 
-    int channelsInFile, freq;
+    int channelsInFile = 0, freq = 0;
     memset(&data->spec, 0, sizeof(SDL_AudioSpec));
     // Loading the OGG file
     data->length = stb_vorbis_decode_memory(fileBuffer, length, &channelsInFile, &freq, &tempBuffer);


### PR DESCRIPTION
This only partially address #3 by adding the missing ogg file to the game.egg. 

We still need to decide on an appropriate error handling strategy, so I will defer on that part. 