### PR TITLE
Introduce a DOME module and an exit function

### DIFF
--- a/main.wren
+++ b/main.wren
@@ -2,6 +2,7 @@ import "input" for Keyboard
 import "graphics" for Canvas, Color, ImageData, Point
 import "audio" for AudioEngine
 import "random" for Random
+import "dome" for Process
 import "./test"
 
 import "io" for FileSystem
@@ -253,6 +254,9 @@ class MainGame {
       }
       if (Keyboard.isKeyDown("down")) {
         y = 1
+      }
+      if (Keyboard.isKeyDown("escape")) {
+        Process.exit()
       }
       if (Keyboard.isKeyDown("space")) {
         if ((__t - __lastFire) > 10) {

--- a/src/engine.c
+++ b/src/engine.c
@@ -9,6 +9,8 @@ typedef struct {
   uint32_t width;
   uint32_t height;
   mtar_t* tar;
+  bool running;
+  int exit_status;
 } ENGINE;
 
 typedef enum {
@@ -120,6 +122,7 @@ ENGINE_init(ENGINE* engine) {
   engine->fifo.taskHandler = ENGINE_taskHandler;
 
   ModuleMap_init(&engine->moduleMap);
+  engine->running = true;
 
 engine_init_end:
   return result;

--- a/src/engine/dome.c
+++ b/src/engine/dome.c
@@ -1,0 +1,11 @@
+// This informs the engine we want to stop running, but we have to wait until
+// we reach the main loop to quit.
+void DOME_exit(WrenVM* vm) {
+  ENGINE* engine = (ENGINE*)wrenGetUserData(vm);
+  engine->running = false;
+  engine->exit_status = floor(wrenGetSlotDouble(vm, 1));
+  if (engine->exit_status != 0) {
+    wrenAbortFiber(vm, 1);
+  }
+}
+

--- a/src/engine/dome.c
+++ b/src/engine/dome.c
@@ -1,11 +1,12 @@
-// This informs the engine we want to stop running, but we have to wait until
-// we reach the main loop to quit.
+// This informs the engine we want to stop running, and jumps to the end of the game loop if we have no errors to report.
 void DOME_exit(WrenVM* vm) {
   ENGINE* engine = (ENGINE*)wrenGetUserData(vm);
   engine->running = false;
   engine->exit_status = floor(wrenGetSlotDouble(vm, 1));
   if (engine->exit_status != 0) {
     wrenAbortFiber(vm, 1);
+  } else {
+    longjmp(loop_exit,1);
   }
 }
 

--- a/src/engine/dome.c
+++ b/src/engine/dome.c
@@ -1,5 +1,5 @@
 // This informs the engine we want to stop running, and jumps to the end of the game loop if we have no errors to report.
-void DOME_exit(WrenVM* vm) {
+void PROCESS_exit(WrenVM* vm) {
   ENGINE* engine = (ENGINE*)wrenGetUserData(vm);
   engine->running = false;
   engine->exit_status = floor(wrenGetSlotDouble(vm, 1));

--- a/src/engine/dome.c
+++ b/src/engine/dome.c
@@ -6,7 +6,7 @@ void DOME_exit(WrenVM* vm) {
   if (engine->exit_status != 0) {
     wrenAbortFiber(vm, 1);
   } else {
-    longjmp(loop_exit,1);
+    longjmp(loop_exit, EXIT_SUCCESS);
   }
 }
 

--- a/src/engine/dome.wren
+++ b/src/engine/dome.wren
@@ -1,0 +1,7 @@
+class DOME {
+  foreign static f_exit(n)
+  static exit(n) { f_exit(n) }
+  static exit() {
+    exit(0)
+  }
+}

--- a/src/engine/dome.wren
+++ b/src/engine/dome.wren
@@ -1,4 +1,4 @@
-class DOME {
+class Process {
   foreign static f_exit(n)
   static exit(n) { f_exit(n) }
   static exit() {

--- a/src/engine/modules.c
+++ b/src/engine/modules.c
@@ -1,3 +1,4 @@
+#include "dome.wren.inc"
 #include "audio.wren.inc"
 #include "graphics.wren.inc"
 #include "point.wren.inc"
@@ -59,6 +60,7 @@ ModuleMap_get(ModuleMap* map, const char* name) {
 internal void
 ModuleMap_init(ModuleMap* map) {
   map->head = NULL;
+  ModuleMap_add(map, "dome", domeModule);
   ModuleMap_add(map, "input", inputModule);
   ModuleMap_add(map, "io", ioModule);
   ModuleMap_add(map, "graphics", graphicsModule);

--- a/src/main.c
+++ b/src/main.c
@@ -63,6 +63,7 @@
 #include "io.c"
 #include "engine/modules.c"
 #include "engine.c"
+#include "engine/dome.c"
 #include "engine/io.c"
 #include "engine/audio.c"
 #include "engine/graphics.c"
@@ -191,10 +192,9 @@ int main(int argc, char* args[])
 
   uint32_t previousTime = SDL_GetTicks();
   int32_t lag = 0;
-  bool running = true;
   SDL_Event event;
   SDL_SetRenderDrawColor( engine.renderer, 0x00, 0x00, 0x00, 0x00 );
-  while (running) {
+  while (engine.running) {
     int32_t currentTime = SDL_GetTicks();
     int32_t elapsed = currentTime - previousTime;
     previousTime = currentTime;
@@ -205,7 +205,7 @@ int main(int argc, char* args[])
       switch (event.type)
       {
         case SDL_QUIT:
-          running = false;
+          engine.running = false;
           break;
         case SDL_KEYDOWN:
         case SDL_KEYUP:
@@ -213,7 +213,7 @@ int main(int argc, char* args[])
             SDL_Keycode keyCode = event.key.keysym.sym;
             if(keyCode == SDLK_ESCAPE && event.key.state == SDL_PRESSED && event.key.repeat == 0) {
               // TODO: Let Wren decide when to end game
-              running = false;
+              engine.running = false;
             } else if (keyCode == SDLK_F2 && event.key.state == SDL_PRESSED && event.key.repeat == 0) {
               for (size_t i = 0; i < imageSize; i++) {
                 uint32_t c = ((uint32_t*)engine.pixels)[i];

--- a/src/main.c
+++ b/src/main.c
@@ -215,10 +215,7 @@ int main(int argc, char* args[])
         case SDL_KEYUP:
           {
             SDL_Keycode keyCode = event.key.keysym.sym;
-            if(keyCode == SDLK_ESCAPE && event.key.state == SDL_PRESSED && event.key.repeat == 0) {
-              // TODO: Let Wren decide when to end game
-              engine.running = false;
-            } else if (keyCode == SDLK_F2 && event.key.state == SDL_PRESSED && event.key.repeat == 0) {
+            if (keyCode == SDLK_F2 && event.key.state == SDL_PRESSED && event.key.repeat == 0) {
               for (size_t i = 0; i < imageSize; i++) {
                 uint32_t c = ((uint32_t*)engine.pixels)[i];
                 uint8_t a = (0xFF000000 & c) >> 24;

--- a/src/main.c
+++ b/src/main.c
@@ -296,7 +296,7 @@ int main(int argc, char* args[])
     // SDL_SetWindowTitle(engine.window, buffer);
 
     elapsed = SDL_GetTicks() - currentTime;
-    setjmp(loop_exit);
+    result = setjmp(loop_exit);
   }
   if (makeGif) {
     jo_gif_end(&gif);

--- a/src/main.c
+++ b/src/main.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <math.h>
 #include <libgen.h>
+#include <setjmp.h>
 
 #include <wren.h>
 #include <SDL2/SDL.h>
@@ -54,6 +55,9 @@
 #define SCREEN_HEIGHT GAME_HEIGHT * 2
 #define FPS 60
 #define MS_PER_FRAME 1000 / FPS
+
+// We need this here so it can be used by the DOME module
+global_variable jmp_buf loop_exit;
 
 // Game code
 #include "math.c"
@@ -292,6 +296,7 @@ int main(int argc, char* args[])
     // SDL_SetWindowTitle(engine.window, buffer);
 
     elapsed = SDL_GetTicks() - currentTime;
+    setjmp(loop_exit);
   }
   if (makeGif) {
     jo_gif_end(&gif);

--- a/src/util/generateEmbedModules.sh
+++ b/src/util/generateEmbedModules.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 gcc embed.c -o embed -std=c99
+./embed ../engine/dome.wren domeModule ../engine/dome.wren.inc
 ./embed ../engine/init.wren initModule ../engine/init.wren.inc
 ./embed ../engine/input.wren inputModule ../engine/input.wren.inc
 ./embed ../engine/graphics.wren graphicsModule ../engine/graphics.wren.inc

--- a/src/vm.c
+++ b/src/vm.c
@@ -105,6 +105,8 @@ internal WrenVM* VM_create(ENGINE* engine) {
 
   // Set modules
 
+  // DOME
+  MAP_add(&engine->fnMap, "dome", "DOME", "f_exit(_)", true, DOME_exit);
   // Canvas
   MAP_add(&engine->fnMap, "graphics", "Canvas", "f_pset(_,_,_)", true, CANVAS_pset);
   MAP_add(&engine->fnMap, "graphics", "Canvas", "f_rectfill(_,_,_,_,_)", true, CANVAS_rectfill);

--- a/src/vm.c
+++ b/src/vm.c
@@ -106,7 +106,7 @@ internal WrenVM* VM_create(ENGINE* engine) {
   // Set modules
 
   // DOME
-  MAP_add(&engine->fnMap, "dome", "DOME", "f_exit(_)", true, DOME_exit);
+  MAP_add(&engine->fnMap, "dome", "Process", "f_exit(_)", true, PROCESS_exit);
   // Canvas
   MAP_add(&engine->fnMap, "graphics", "Canvas", "f_pset(_,_,_)", true, CANVAS_pset);
   MAP_add(&engine->fnMap, "graphics", "Canvas", "f_rectfill(_,_,_,_,_)", true, CANVAS_rectfill);


### PR DESCRIPTION
Implements request #5 

There is now a DOME module which can contain DOME-centric configuration
methods and properties. It also adds an `exit` method which can be used
by a game to exit the execution.

~~A caveat to this is that you can't quit a VM from within the C code,
so we need to wait for the execution to reach the core engine loop
before we can safely shutdown the Wren VM.~~

EDIT: We can use setjmp/longjmp to bypass the WrenVM execution and execute the DOME shutdown sequence, which cleans up memory safely.