### PR TITLE
File API Changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ EXENAME = dome
 ifeq ($(MODE), debug)
 	LDFLAGS += -lwrend
 	CFLAGS += -g -fsanitize=address -O0
+  DOME_OPTS += -DDEBUG=1
   $(shell echo $(MODE) > .mode)
 else
 	LDFLAGS += -lwren

--- a/README.md
+++ b/README.md
@@ -79,24 +79,22 @@ DOME provides the following modules/methods/classes:
   - Mouse
   - Gamepads
 - Filesystem
-  - File reading
-  - Asynchronous (Unstable API)
+  - File reading and writing
 - Audio (stereo and mono OGG and WAV files only)
 
 ## TODO
 You can follow my progress on implementing DOME on [my twitter](https://twitter.com/avivbeeri/status/1012448692119457798).
 
 - IO
-  - Writing to files
+  - Asynchronous Operations (Unstable API)
 - Loading Audio and Graphics asynchronously
 - Graphics 
   - Triangles
 - Network Access
   - UDP
   - HTTP client (optional)
-- Math (Better API for Num class functions)
+- Math (More intuitive API for Num class functions)
 - Robust error checking and sandboxing
-- Memory leak checks
 
 ## Dependencies
 

--- a/docs/modules/io.md
+++ b/docs/modules/io.md
@@ -13,7 +13,10 @@ It contains the following classes:
 
 ### Static Methods
 
-#### `static loadSync(path: String): String`
-Given a valid file path, this loads the file data into a String object.
+#### `static load(path: String): String`
+Given a valid file `path`, this loads the file data into a String object.
 This is a blocking operation, and so execution will stop while the file is loaded.
 
+#### `static save(path: String, buffer: String): Void`
+Given a valid file `path`, this will create or overwrite the file the data in the `buffer` String object.
+This is a blocking operation, and so execution will stop while the file is saved.

--- a/main.wren
+++ b/main.wren
@@ -34,19 +34,12 @@ class Game {
     System.print(Window.title)
     __state = MainGame
     __state.init()
-    __done = false
 
-    __loadSettingsOp = FileSystem.load("setup_wren.sh")
-    System.print(__loadSettingsOp.result.length)
+    __settingsFile = FileSystem.load("setup_wren.sh")
+    System.print(__settingsFile)
   }
   static update() {
 
-    if (__loadSettingsOp.complete && !__done) {
-      __settingsFile = __loadSettingsOp.result
-      __done = true
-      System.print("loaded")
-      System.print(__settingsFile.data)
-    }
     __x = Mouse.x
     __y = Mouse.y
 

--- a/src/audio_types.c
+++ b/src/audio_types.c
@@ -1,0 +1,6 @@
+typedef enum {
+  AUDIO_TYPE_UNKNOWN,
+  AUDIO_TYPE_WAV,
+  AUDIO_TYPE_OGG
+} AUDIO_TYPE;
+

--- a/src/debug.c
+++ b/src/debug.c
@@ -8,7 +8,14 @@ internal void DEBUG_printString(char* str) {
   printf("%s\n", str);
 }
 
-internal void DEBUG_printAudioSpec(SDL_AudioSpec spec) {
+internal void DEBUG_printAudioSpec(SDL_AudioSpec spec, AUDIO_TYPE type) {
+  if (type == AUDIO_TYPE_WAV) {
+    printf("WAV ");
+  } else if (type == AUDIO_TYPE_WAV) {
+    printf("OGG ");
+  } else {
+    printf("Unknown audio file detected\n");
+  }
   printf("Audio: %i Hz ", spec.freq);
   printf("%s", spec.channels == 0 ? "Mono" : "Stereo");
   printf(" - ");

--- a/src/engine.c
+++ b/src/engine.c
@@ -46,7 +46,31 @@ typedef enum {
   TASK_WRITE_FILE_APPEND
 } TASK_TYPE;
 
+typedef enum {
+  ENGINE_WRITE_SUCCESS,
+  ENGINE_WRITE_PATH_INVALID
+} ENGINE_WRITE_RESULT;
+
 global_variable uint32_t ENGINE_EVENT_TYPE;
+
+internal ENGINE_WRITE_RESULT
+ENGINE_writeFile(ENGINE* engine, char* path, char* buffer, size_t length) {
+  char* base = SDL_GetBasePath();
+  char* fullPath = malloc(strlen(base)+strlen(path)+1);
+  strcpy(fullPath, base); /* copy name into the new var */
+  strcat(fullPath, path); /* add the extension */
+  SDL_free(base);
+
+  int result = writeEntireFile(fullPath, buffer, length);
+  if (result == ENOENT) {
+    result = ENGINE_WRITE_PATH_INVALID;
+  } else {
+    result = ENGINE_WRITE_SUCCESS;
+  }
+  free(fullPath);
+
+  return result;
+}
 
 internal char*
 ENGINE_readFile(ENGINE* engine, char* path, size_t* lengthPtr) {

--- a/src/engine.c
+++ b/src/engine.c
@@ -152,6 +152,7 @@ ENGINE_init(ENGINE* engine) {
   engine->texture = NULL;
   engine->pixels = NULL;
   engine->lockstep = false;
+  engine->debug.avgFps = 58;
   engine->debugEnabled = false;
   engine->debug.alpha = 0.9;
   engine->width = GAME_WIDTH;

--- a/src/io.c
+++ b/src/io.c
@@ -28,6 +28,17 @@ char* readFileFromTar(mtar_t* tar, char* path, size_t* lengthPtr) {
   return p;
 }
 
+int writeEntireFile(char* path, char* data, size_t length) {
+  printf("Writing to filesystem: %s\n", path);
+  FILE* file = fopen(path, "wb+");
+  if (file == NULL) {
+    return errno;
+  }
+  fwrite(data, sizeof(char), length, file);
+  fclose(file);
+  return 0;
+}
+
 char* readEntireFile(char* path, size_t* lengthPtr) {
   printf("Reading from filesystem: %s\n", path);
   FILE* file = fopen(path, "rb");

--- a/src/main.c
+++ b/src/main.c
@@ -86,6 +86,7 @@ global_variable jmp_buf loop_exit;
 global_variable WrenHandle* bufferClass = NULL;
 
 // These are set by cmd arguments
+global_variable bool DEBUG_MODE = false;
 global_variable size_t INITIAL_HEAP_SIZE = 1024 * 1024 * 100;
 global_variable size_t AUDIO_BUFFER_SIZE = 2048;
 
@@ -139,12 +140,12 @@ printVersion(void) {
 internal void
 printUsage(void) {
   printf("\nUsage: \n");
-  printf("  dome [entry path]\n");
-  printf("  dome [-r<gif> | --record=<gif>] [-b<buf> | --buffer=<buf>] [-i<size> | --initial-heap=<size>] [entry path]\n");
+  printf("  dome [-d | --debug] [-r<gif> | --record=<gif>] [-b<buf> | --buffer=<buf>] [-i<size> | --initial-heap=<size>] [entry path]\n");
   printf("  dome -h | --help\n");
   printf("  dome -v | --version\n");
   printf("\nOptions: \n");
   printf("  -b --buffer=<buf>   Set the audio buffer size (default: 11)\n");
+  printf("  -d --debug          Enables debug mode\n");
   printf("  -h --help           Show this screen.\n");
   printf("  -v --version        Show version.\n");
   printf("  -r --record=<gif>   Record video to <gif>.\n");
@@ -176,6 +177,7 @@ int main(int argc, char* args[])
   // TODO: Use getopt to parse the arguments better
   struct optparse_long longopts[] = {
     {"buffer", 'b', OPTPARSE_REQUIRED},
+    {"debug", 'd', OPTPARSE_NONE},
     {"initial", 'i', OPTPARSE_REQUIRED},
     {"help", 'h', OPTPARSE_NONE},
     {"version", 'v', OPTPARSE_NONE},
@@ -197,6 +199,10 @@ int main(int argc, char* args[])
           }
           AUDIO_BUFFER_SIZE = 1 << shift;
         } break;
+      case 'd':
+        DEBUG_MODE = true;
+        printf("Debug Mode enabled\n");
+        break;
       case 'h':
         printTitle();
         printUsage();

--- a/src/main.c
+++ b/src/main.c
@@ -86,13 +86,18 @@ global_variable jmp_buf loop_exit;
 global_variable WrenHandle* bufferClass = NULL;
 
 // These are set by cmd arguments
+#ifdef DEBUG
+global_variable bool DEBUG_MODE = true;
+#else
 global_variable bool DEBUG_MODE = false;
+#endif
 global_variable size_t INITIAL_HEAP_SIZE = 1024 * 1024 * 100;
 global_variable size_t AUDIO_BUFFER_SIZE = 2048;
 
 // Game code
 #include "math.c"
 #include "strings.c"
+#include "audio_types.c"
 #include "debug.c"
 /*
 #include "util/font.c"

--- a/src/main.c
+++ b/src/main.c
@@ -5,6 +5,7 @@
 
 // Standard libs
 #include <stdio.h>
+#include <errno.h>
 #include <stdlib.h>
 #include <ctype.h>
 

--- a/src/modules/audio.c
+++ b/src/modules/audio.c
@@ -1,12 +1,5 @@
 #define AUDIO_CHANNEL_START 2
 
-#define AUDIO_TYPE_UNKNOWN 0
-#define AUDIO_TYPE_WAV 1
-#define AUDIO_TYPE_OGG 2
-
-typedef uint8_t AUDIO_TYPE;
-
-
 typedef struct {
   SDL_AudioSpec spec;
   AUDIO_TYPE audioType;
@@ -110,7 +103,6 @@ internal void AUDIO_allocate(WrenVM* vm) {
   int16_t* tempBuffer;
   if (strncmp(fileBuffer, "RIFF", 4) == 0 &&
       strncmp(&fileBuffer[8], "WAVE", 4) == 0) {
-    printf("WAV file detected\n");
     data->audioType = AUDIO_TYPE_WAV;
 
     // Loading the WAV file
@@ -122,7 +114,6 @@ internal void AUDIO_allocate(WrenVM* vm) {
     }
     data->length /= sizeof(int16_t) * data->spec.channels;
   } else if (strncmp(fileBuffer, "OggS", 4) == 0) {
-    printf("OGG file detected\n");
     data->audioType = AUDIO_TYPE_OGG;
 
     int channelsInFile = 0, freq = 0;
@@ -161,7 +152,9 @@ internal void AUDIO_allocate(WrenVM* vm) {
   } else if (data->audioType == AUDIO_TYPE_OGG) {
     free(tempBuffer);
   }
-  DEBUG_printAudioSpec(data->spec);
+  if (DEBUG_MODE) {
+    DEBUG_printAudioSpec(data->spec, data->audioType);
+  }
 }
 
 internal void AUDIO_finalize(void* data) {

--- a/src/modules/audio.wren
+++ b/src/modules/audio.wren
@@ -5,7 +5,7 @@ import "io" for FileSystem
 foreign class AudioData {
   construct init(buffer) {}
   static fromFile(path) {
-    var data = AudioData.init(FileSystem.loadSync(path))
+    var data = AudioData.init(FileSystem.load(path))
     System.print("Audio loaded: " + path)
     return data
   }

--- a/src/modules/graphics.wren
+++ b/src/modules/graphics.wren
@@ -201,7 +201,7 @@ foreign class ImageData {
     }
 
     if (!__cache.containsKey(path)) {
-      var data = FileSystem.loadSync(path)
+      var data = FileSystem.load(path)
       __cache[path] = ImageData.initFromFile(data)
     }
 

--- a/src/modules/io.c
+++ b/src/modules/io.c
@@ -143,8 +143,23 @@ FILESYSTEM_loadEventHandler(void* data) {
 }
 
 internal void
+FILESYSTEM_saveSync(WrenVM* vm) {
+  int length;
+  const char* path = wrenGetSlotString(vm, 1);
+  const char* data = wrenGetSlotBytes(vm, 2, &length);
+  ENGINE* engine = (ENGINE*)wrenGetUserData(vm);
+  ENGINE_WRITE_RESULT result = ENGINE_writeFile(engine, path, data, length);
+  if (result == ENGINE_WRITE_PATH_INVALID) {
+    size_t len = 22 + strlen(path);
+    char message[len];
+    snprintf(message, len, "Could not find file: %s", path);
+    VM_ABORT(vm, message);
+    return;
+  }
+}
+
+internal void
 FILESYSTEM_loadSync(WrenVM* vm) {
-  // TODO: We should return a DataBuffer object rather than a string
   const char* path = wrenGetSlotString(vm, 1);
   ENGINE* engine = (ENGINE*)wrenGetUserData(vm);
 

--- a/src/modules/io.wren
+++ b/src/modules/io.wren
@@ -1,35 +1,22 @@
 class FileSystem {
-  foreign static f_load(path, op)
-  // foreign static f_write_buffer(path, buffer, op) {}
-  // foreign static f_write_string(path, str, op) {}
-  // foreign f_append(path, buffer, op) {}
+  static loadSync(path) {
+    System.print("WARN: 'loadSync(_)' is depreciated. Use 'load(_)' instead.")
+    return load(path)
+  }
+  static saveSync(path, buffer) {
+    System.print("WARN: 'saveSync(_, _)' is depreciated. Use 'save(_, _)' instead.")
+    return save(path, buffer)
+  }
+  foreign static load(path)
+  foreign static save(path, buffer)
 
-  static load(path) {
+  // @Unstable - DO NOT USE
+  foreign static f_load(path, op)
+  static loadAsync(path) {
     var operation = AsyncOperation.init(null)
     f_load(path, operation)
     return operation
   }
-
-  foreign static loadSync(path)
-
-  /*
-  // Overwrites entire path
-  static write(path, buffer) {
-    operation = AsyncOperation.init()
-    operation.create(DataBuffer.create())
-    if (buffer is String) {
-      f_write_string(path, buffer, operation)
-    } else if (buffer is DataBuffer) {
-      f_write_buffer(path, buffer, operation)
-    } else {
-      Fiber.abort("Attempted to write unknown buffer type")
-    }
-    return operation
-  }
-  */
-
-  // Append
-
 }
 
 foreign class AsyncOperation {

--- a/src/vm.c
+++ b/src/vm.c
@@ -101,14 +101,14 @@ internal void VM_write(WrenVM* vm, const char* text) {
 internal void VM_error(WrenVM* vm, WrenErrorType type, const char* module,
     int line, const char* message) {
 
-  #ifndef DEBUG
-  ENGINE* engine = (ENGINE*)wrenGetUserData(vm);
-  ModuleMap moduleMap = engine->moduleMap;
+  if (DEBUG_MODE == false) {
+    ENGINE* engine = (ENGINE*)wrenGetUserData(vm);
+    ModuleMap moduleMap = engine->moduleMap;
 
-  if (module != NULL && ModuleMap_get(&moduleMap, module) != NULL) {
-    return;
+    if (module != NULL && ModuleMap_get(&moduleMap, module) != NULL) {
+      return;
+    }
   }
-  #endif
 
   if (type == WREN_ERROR_COMPILE) {
     printf("%s:%d: %s\n", module, line, message);

--- a/src/vm.c
+++ b/src/vm.c
@@ -74,12 +74,16 @@ internal WrenForeignMethodFn VM_bind_foreign_method(
 }
 
 internal char* VM_load_module(WrenVM* vm, const char* name) {
-  printf("Loading module %s\n", name);
   ENGINE* engine = (ENGINE*)wrenGetUserData(vm);
   ModuleMap moduleMap = engine->moduleMap;
   if (strncmp("./", name, 2) != 0) {
+    if (DEBUG_MODE) {
+      printf("Loading module %s\n", name);
+    }
     return (char*)ModuleMap_get(&moduleMap, name);
   }
+
+  printf("Loading module %s\n", name);
 
   char* extension = ".wren";
   char* path;

--- a/src/vm.c
+++ b/src/vm.c
@@ -100,6 +100,16 @@ internal void VM_write(WrenVM* vm, const char* text) {
 
 internal void VM_error(WrenVM* vm, WrenErrorType type, const char* module,
     int line, const char* message) {
+
+  #ifndef DEBUG
+  ENGINE* engine = (ENGINE*)wrenGetUserData(vm);
+  ModuleMap moduleMap = engine->moduleMap;
+
+  if (module != NULL && ModuleMap_get(&moduleMap, module) != NULL) {
+    return;
+  }
+  #endif
+
   if (type == WREN_ERROR_COMPILE) {
     printf("%s:%d: %s\n", module, line, message);
   } else if (type == WREN_ERROR_RUNTIME) {
@@ -174,7 +184,8 @@ internal WrenVM* VM_create(ENGINE* engine) {
 
   // FileSystem
   MAP_add(&engine->fnMap, "io", "FileSystem", "f_load(_,_)", true, FILESYSTEM_load);
-  MAP_add(&engine->fnMap, "io", "FileSystem", "loadSync(_)", true, FILESYSTEM_loadSync);
+  MAP_add(&engine->fnMap, "io", "FileSystem", "load(_)", true, FILESYSTEM_loadSync);
+  MAP_add(&engine->fnMap, "io", "FileSystem", "save(_,_)", true, FILESYSTEM_saveSync);
 
   // Buffer
   MAP_add(&engine->fnMap, "io", "DataBuffer", "f_data", false, DBUFFER_getData);


### PR DESCRIPTION
This PR breaks the old API a little bit, by  moving `load` to `loadAsync` and instead, `load` is now `loadSync`.

If you use `loadSync` or `saveSync`, you'll be given a warning message.

It also introduces a way to write to files,`save(path, stringBuffer)` which will create and overwrite files.

Other changes:
DOME has a `debug` mode now, enabled by the `-d` or `--debug` flag. This is intended for DOME development, and enables slightly deeper stack traces when errors occur inside DOME built-in methods. The features toggled by this mode can be expanded over time.