### PR TITLE
We use the current working directory for the base path

### DIFF
--- a/src/engine.c
+++ b/src/engine.c
@@ -55,11 +55,10 @@ global_variable uint32_t ENGINE_EVENT_TYPE;
 
 internal ENGINE_WRITE_RESULT
 ENGINE_writeFile(ENGINE* engine, char* path, char* buffer, size_t length) {
-  char* base = SDL_GetBasePath();
+  char* base = getBasePath();
   char* fullPath = malloc(strlen(base)+strlen(path)+1);
   strcpy(fullPath, base); /* copy name into the new var */
   strcat(fullPath, path); /* add the extension */
-  SDL_free(base);
 
   int result = writeEntireFile(fullPath, buffer, length);
   if (result == ENOENT) {
@@ -92,11 +91,10 @@ ENGINE_readFile(ENGINE* engine, char* path, size_t* lengthPtr) {
     printf("Couldn't find %s in bundle, falling back.\n", pathBuf);
   }
 
-  char* base = SDL_GetBasePath();
+  char* base = getBasePath();
   char* fullPath = malloc(strlen(base)+strlen(path)+1);
   strcpy(fullPath, base); /* copy name into the new var */
   strcat(fullPath, path); /* add the extension */
-  SDL_free(base);
   if (!doesFileExist(fullPath)) {
     free(fullPath);
     return NULL;
@@ -175,7 +173,7 @@ ENGINE_init(ENGINE* engine) {
     goto engine_init_end;
   }
 
-  engine->pixels = malloc(engine->width * engine->height * 4);
+  engine->pixels = calloc(engine->width * engine->height, sizeof(char) * 4);
   if (engine->pixels == NULL) {
     result = EXIT_FAILURE;
     goto engine_init_end;

--- a/src/engine.c
+++ b/src/engine.c
@@ -55,7 +55,7 @@ global_variable uint32_t ENGINE_EVENT_TYPE;
 
 internal ENGINE_WRITE_RESULT
 ENGINE_writeFile(ENGINE* engine, char* path, char* buffer, size_t length) {
-  char* base = getBasePath();
+  char* base = BASEPATH_get();
   char* fullPath = malloc(strlen(base)+strlen(path)+1);
   strcpy(fullPath, base); /* copy name into the new var */
   strcat(fullPath, path); /* add the extension */
@@ -91,7 +91,7 @@ ENGINE_readFile(ENGINE* engine, char* path, size_t* lengthPtr) {
     printf("Couldn't find %s in bundle, falling back.\n", pathBuf);
   }
 
-  char* base = getBasePath();
+  char* base = BASEPATH_get();
   char* fullPath = malloc(strlen(base)+strlen(path)+1);
   strcpy(fullPath, base); /* copy name into the new var */
   strcat(fullPath, path); /* add the extension */

--- a/src/io.c
+++ b/src/io.c
@@ -3,12 +3,22 @@ internal void FILESYSTEM_loadEventHandler(void* task);
 global_variable char* basePath = NULL;
 char* getBasePath(void) {
 
-  long path_max;
-  size_t size;
-  char *buf = NULL;
-  char *ptr = NULL;
 
   if (basePath == NULL) {
+    if (STRINGS_EQUAL(SDL_GetPlatform(), "Mac OS X")) {
+      basePath = SDL_GetBasePath();
+      if (strstr(basePath, ".app/") != NULL) {
+        // If this is a MAC bundle, we need to use the exe location
+        return basePath;
+      } else {
+        // Free the SDL path and fall back
+        free(basePath);
+      }
+    }
+    long path_max;
+    size_t size;
+    char *buf = NULL;
+    char *ptr = NULL;
 #ifdef __MINGW32__
     path_max = PATH_MAX;
 #else
@@ -33,19 +43,12 @@ char* getBasePath(void) {
       }
     }
     basePath = ptr;
-
-    if (STRINGS_EQUAL(SDL_GetPlatform(), "Mac OS X") && strstr(basePath, ".app/") != NULL) {
-      // If this is a MAC bundle, we need to use the exe location
-      free(basePath);
-      basePath = SDL_GetBasePath();
-    } else {
-      size_t len = strlen(basePath);
-      *(basePath + len) = '/';
-      *(basePath + len + 1) = '\0';
-      for (size_t i = 0; i < len + 2; i++) {
-        if (basePath[i] == '\\') {
-          basePath[i] = '/';
-        }
+    size_t len = strlen(basePath);
+    *(basePath + len) = '/';
+    *(basePath + len + 1) = '\0';
+    for (size_t i = 0; i < len + 2; i++) {
+      if (basePath[i] == '\\') {
+        basePath[i] = '/';
       }
     }
   }

--- a/src/io.c
+++ b/src/io.c
@@ -34,7 +34,7 @@ char* getBasePath(void) {
     }
     basePath = ptr;
 
-    if (strstr(basePath, ".app/") != NULL) {
+    if (STRINGS_EQUAL(SDL_GetPlatform(), "Mac OS X") && strstr(basePath, ".app/") != NULL) {
       // If this is a MAC bundle, we need to use the exe location
       free(basePath);
       basePath = SDL_GetBasePath();

--- a/src/io.c
+++ b/src/io.c
@@ -1,9 +1,9 @@
 internal void FILESYSTEM_loadEventHandler(void* task);
 
 global_variable char* basePath = NULL;
-char* getBasePath(void) {
 
-
+internal char*
+BASEPATH_get(void) {
   if (basePath == NULL) {
     if (STRINGS_EQUAL(SDL_GetPlatform(), "Mac OS X")) {
       basePath = SDL_GetBasePath();
@@ -55,30 +55,28 @@ char* getBasePath(void) {
   return basePath;
 }
 
-void freeBasePath(void) {
+internal void
+BASEPATH_free(void) {
   if (basePath != NULL) {
     free(basePath);
   }
 }
 
+internal inline
 bool doesFileExist(char* path) {
   return access(path, F_OK) != -1;
 }
 
-char* readFileFromTar(mtar_t* tar, char* path, size_t* lengthPtr) {
+internal char*
+readFileFromTar(mtar_t* tar, char* path, size_t* lengthPtr) {
   // We assume the tar open has been done already
-  /* Open archive for reading */
-  // mtar_t tar;
-  // mtar_open(tar, "game.egg", "r");
-
-  //
 
   printf("Reading from bundle: %s\n", path);
   mtar_header_t h;
   mtar_find(tar, path, &h);
   size_t length = h.size;
-  char* p = calloc(1, length + 1);
-  if (mtar_read_data(tar, p, length) != MTAR_ESUCCESS) {
+  char* buffer = calloc(1, length + 1);
+  if (mtar_read_data(tar, buffer, length) != MTAR_ESUCCESS) {
     printf("Error: Couldn't read the data from the bundle.");
     abort();
   }
@@ -86,10 +84,12 @@ char* readFileFromTar(mtar_t* tar, char* path, size_t* lengthPtr) {
   if (lengthPtr != NULL) {
     *lengthPtr = length;
   }
-  return p;
+
+  return buffer;
 }
 
-int writeEntireFile(char* path, char* data, size_t length) {
+internal int
+writeEntireFile(char* path, char* data, size_t length) {
   printf("Writing to filesystem: %s\n", path);
   FILE* file = fopen(path, "wb+");
   if (file == NULL) {
@@ -100,7 +100,8 @@ int writeEntireFile(char* path, char* data, size_t length) {
   return 0;
 }
 
-char* readEntireFile(char* path, size_t* lengthPtr) {
+internal char*
+readEntireFile(char* path, size_t* lengthPtr) {
   printf("Reading from filesystem: %s\n", path);
   FILE* file = fopen(path, "rb");
   if (file == NULL) {

--- a/src/io.c
+++ b/src/io.c
@@ -34,12 +34,13 @@ char* getBasePath(void) {
     }
     basePath = ptr;
     size_t len = strlen(basePath);
-#ifdef __MINGW32__
-    *(basePath + len) = '\';
-#else
     *(basePath + len) = '/';
-#endif
     *(basePath + len + 1) = '\0';
+    for (size_t i = 0; i < len + 2; i++) {
+      if (basePath[i] == '\\') {
+        basePath[i] = '/';
+      }
+    }
   }
   return basePath;
 }

--- a/src/io.c
+++ b/src/io.c
@@ -34,7 +34,11 @@ char* getBasePath(void) {
     }
     basePath = ptr;
     size_t len = strlen(basePath);
+#ifdef __MINGW32__
+    *(basePath + len) = '\';
+#else
     *(basePath + len) = '/';
+#endif
     *(basePath + len + 1) = '\0';
   }
   return basePath;

--- a/src/io.c
+++ b/src/io.c
@@ -33,12 +33,19 @@ char* getBasePath(void) {
       }
     }
     basePath = ptr;
-    size_t len = strlen(basePath);
-    *(basePath + len) = '/';
-    *(basePath + len + 1) = '\0';
-    for (size_t i = 0; i < len + 2; i++) {
-      if (basePath[i] == '\\') {
-        basePath[i] = '/';
+
+    if (strstr(basePath, ".app/") != NULL) {
+      // If this is a MAC bundle, we need to use the exe location
+      free(basePath);
+      basePath = SDL_GetBasePath();
+    } else {
+      size_t len = strlen(basePath);
+      *(basePath + len) = '/';
+      *(basePath + len + 1) = '\0';
+      for (size_t i = 0; i < len + 2; i++) {
+        if (basePath[i] == '\\') {
+          basePath[i] = '/';
+        }
       }
     }
   }

--- a/src/io.c
+++ b/src/io.c
@@ -9,8 +9,11 @@ char* getBasePath(void) {
   char *ptr = NULL;
 
   if (basePath == NULL) {
-
+#ifdef __MINGW32__
+    path_max = PATH_MAX;
+#else
     path_max = pathconf(".", _PC_PATH_MAX);
+#endif
     if (path_max == -1) {
       size = 1024;
     } else if (path_max > 10240) {

--- a/src/main.c
+++ b/src/main.c
@@ -249,7 +249,7 @@ int main(int argc, char* args[])
   {
     char* fileName = "game.egg";
     char* mainFileName = "main.wren";
-    char* base = getBasePath();
+    char* base = BASEPATH_get();
     char* arg = optparse_arg(&options);
     if (arg != NULL) {
       fileName = arg;
@@ -514,7 +514,7 @@ vm_cleanup:
 cleanup:
   // Free resources
   // TODO: Lock the Audio Engine here.
-  freeBasePath();
+  BASEPATH_free();
   AUDIO_ENGINE_halt(engine.audioEngine);
   VM_free(vm);
   ENGINE_free(&engine);

--- a/src/main.c
+++ b/src/main.c
@@ -249,7 +249,7 @@ int main(int argc, char* args[])
   {
     char* fileName = "game.egg";
     char* mainFileName = "main.wren";
-    char* base = SDL_GetBasePath();
+    char* base = getBasePath();
     char* arg = optparse_arg(&options);
     if (arg != NULL) {
       fileName = arg;
@@ -257,7 +257,6 @@ int main(int argc, char* args[])
     char pathBuf[strlen(base)+strlen(fileName)+1];
     strcpy(pathBuf, base);
     strcat(pathBuf, fileName);
-    SDL_free(base);
 
     if (doesFileExist(pathBuf)) {
       engine.tar = malloc(sizeof(mtar_t));
@@ -515,6 +514,7 @@ vm_cleanup:
 cleanup:
   // Free resources
   // TODO: Lock the Audio Engine here.
+  freeBasePath();
   AUDIO_ENGINE_halt(engine.audioEngine);
   VM_free(vm);
   ENGINE_free(&engine);


### PR DESCRIPTION
If you tried to install dome onto the user bin path, or wanted to symlink DOME for VCS purposes (see #31 ) you'd find problems as DOME used the location of it's executable, rather than the current working directory.

NOTE: This probably breaks application bundles for OS X at the moment. We need to detect if we are in a bundle and then use that location.