### PR TITLE
Lazy-capture AudioEngine and DataBuffer classes

### DIFF
--- a/src/modules/audio.c
+++ b/src/modules/audio.c
@@ -42,6 +42,14 @@ const uint16_t bytesPerSample = 2 * 2 /* channels */;
 // Allows SDL to "pull" data into the output buffer
 // on a seperate thread. We need to be pretty efficient
 // here as it holds a lock.
+internal void
+AUDIO_ENGINE_capture(WrenVM* vm) {
+  if (audioEngineClass == NULL) {
+    wrenGetVariable(vm, "audio", "AudioEngine", 0);
+    audioEngineClass = wrenGetSlotHandle(vm, 0);
+  }
+}
+
 void AUDIO_ENGINE_mix(void*  userdata,
     Uint8* stream,
     int    outputBufferSize) {

--- a/src/modules/audio.wren
+++ b/src/modules/audio.wren
@@ -28,7 +28,9 @@ class AudioEngine {
     __files = {}
     __channels = {}
     __newChannelId = 0
+    f_captureVariable()
   }
+  foreign static f_captureVariable()
   // TODO: Allow device enumeration and selection
 
   // Loading and unloading

--- a/src/modules/io.c
+++ b/src/modules/io.c
@@ -52,6 +52,13 @@ ASYNCOP_getResult(WrenVM* vm) {
   wrenSetSlotHandle(vm, 0, op->bufferHandle);
 }
 
+internal void
+DBUFFER_capture(WrenVM* vm) {
+  if (bufferClass == NULL) {
+    wrenGetVariable(vm, "io", "DataBuffer", 0);
+    bufferClass = wrenGetSlotHandle(vm, 0);
+  }
+}
 
 internal void
 DBUFFER_allocate(WrenVM* vm) {

--- a/src/modules/io.wren
+++ b/src/modules/io.wren
@@ -51,7 +51,10 @@ foreign class DataBuffer {
     }
   }
   // TODO: Index value read and write
+
+  foreign static f_capture()
 }
+DataBuffer.f_capture()
 
 /*
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -185,6 +185,7 @@ internal WrenVM* VM_create(ENGINE* engine) {
   MAP_add(&engine->fnMap, "audio", "AudioChannel", "id", false, AUDIO_CHANNEL_getId);
   MAP_add(&engine->fnMap, "audio", "AudioData", "unload()", false, AUDIO_unload);
   MAP_add(&engine->fnMap, "audio", "AudioEngine", "f_update(_)", true, AUDIO_ENGINE_update);
+  MAP_add(&engine->fnMap, "audio", "AudioEngine", "f_captureVariable()", true, AUDIO_ENGINE_capture);
 
   // FileSystem
   MAP_add(&engine->fnMap, "io", "FileSystem", "f_load(_,_)", true, FILESYSTEM_loadAsync);
@@ -192,6 +193,7 @@ internal WrenVM* VM_create(ENGINE* engine) {
   MAP_add(&engine->fnMap, "io", "FileSystem", "save(_,_)", true, FILESYSTEM_saveSync);
 
   // Buffer
+  MAP_add(&engine->fnMap, "io", "DataBuffer", "f_capture()", true, DBUFFER_capture);
   MAP_add(&engine->fnMap, "io", "DataBuffer", "f_data", false, DBUFFER_getData);
   MAP_add(&engine->fnMap, "io", "DataBuffer", "ready", false, DBUFFER_getReady);
   MAP_add(&engine->fnMap, "io", "DataBuffer", "f_length", false, DBUFFER_getLength);


### PR DESCRIPTION
Based on how the Wren CLI captures variables, we lazy-load the audioEngine and DataBuffer classes as they are loaded