### PR TITLE
Simple rotate and scale

### DIFF
--- a/docs/modules/graphics.md
+++ b/docs/modules/graphics.md
@@ -78,6 +78,20 @@ Create a new color with the given RGB values between `0 - 255`, and an alpha val
 #### `construct new(r: Number, g: Number, b: Number, a: Number)`
 Create a new color with the given RGBA values between `0 - 255`.
 
+### Instance Fields
+
+#### `r: Number`
+A value between `0 - 255` to represent the red color channel.
+
+#### `g: Number`
+A value between `0 - 255` to represent the green color channel.
+
+#### `b: Number`
+A value between `0 - 255` to represent the blue color channel.
+
+#### `a: Number`
+A value between `0 - 255` to represent the alpha transparency channel.
+
 ### Default Palette
 The values for the colors in this palette can be found [here](https://www.romanzolotarev.com/pico-8-color-palette/).
 

--- a/docs/modules/graphics.md
+++ b/docs/modules/graphics.md
@@ -120,6 +120,7 @@ This returns a `Drawable` which will perform the specified transforms, allowing 
  * `srcW`, `srcH` - This is the width and height of the source image region you want to draw.
  * `scaleX`, `scaleY` - You can scale your image in the x and y axis, independant of each other. If either of these are negative, they result in a "flip" operation.
  * `angle` - Rotates the image. This is in degrees, and rounded to the nearest 90 degrees.
+ * `mode`, `foreground` and `background` - By default, mode is `"RGBA"`, so your images will draw in their true colors. If you set it to `"MONO"`, any pixels which are black or have transparency will be drawn in the `background` color and all other pixels of the image will be drawn in the `foreground` color. Both colors must be `Color` objects, and default to `Color.black` and `Color.white`, respectively.
 
 Transforms are applied as follows: Crop to the region, then rotate, then scale/flip.
 

--- a/docs/modules/graphics.md
+++ b/docs/modules/graphics.md
@@ -9,6 +9,7 @@ It contains the following classes:
 
 * [Canvas](#canvas)
 * [Color](#color)
+* [Drawable](#drawable)
 * [ImageData](#imagedata)
 * [Vector](#vector)
 
@@ -35,7 +36,7 @@ This clears the canvas fully, to black.
 #### `static cls(c: Color) `
 This clears the canvas fully, to the color _c_.
 
-#### `static draw(object, x: Number, y: Number) `
+#### `static draw(object: Drawable, x: Number, y: Number) `
 This method is syntactic sugar, to draw objects with a "draw(x: Number, y: Number)" method.
 
 #### `static ellipse(x0: Number, y0: Number, x1: Number, y1: Number, c: Color) `
@@ -82,8 +83,14 @@ An instance of the `Color` class represents a single color which can be used for
 #### `static red: Color`
 #### `static white: Color`
 
+## Drawable
+Represents an object which can be drawn to the screen. Objects which conform to this interface can be passed to `Canvas.draw(drawable, x, y)`.
+### Instance Methods
+#### `draw(x: Number, y: Number): Void`
+Draw the image at the given `(x, y)` position on the screen.
 
 ## ImageData
+### _extends Drawable_
 
 This class represents the data from an image, such as a sprite or tilemap. 
 DOME supports the following formats:
@@ -101,10 +108,20 @@ Load an image at the given `path` and cache it for use.
 
 ### Instance Methods
 #### `draw(x: Number, y: Number): Void`
-Draw the image at the given `(x, y)` position on the screen. This is synonymous with `Canvas.draw(imageData, x, y)`.
+Draw the image at the given `(x, y)` position on the screen.
 
 #### `drawArea(srcX: Number, srcY: Number, srcW: Number, srcH: Number, destX: Number, destY: Number): Void`
 Draw a subsection of the image, defined by the rectangle `(srcX, srcY)` to `(srcX + srcW, srcY + srcH)`. The resulting section is placed at `(destX, destY)`.
+
+#### `transform(parameterMap): Drawable`
+This returns a `Drawable` which will perform the specified transforms, allowing for more fine-grained control over how images are drawn. Options available are:
+
+ * `srcX`, `srcY` - These specify the top-left corner of the source image region you wish to draw.
+ * `srcW`, `srcH` - This is the width and height of the source image region you want to draw.
+ * `scaleX`, `scaleY` - You can scale your image in the x and y axis, independant of each other. If either of these are negative, they result in a "flip" operation.
+ * `angle` - Rotates the image. This is in degrees, and rounded to the nearest 90 degrees.
+
+Transforms are applied as follows: Crop to the region, then rotate, then scale/flip.
 
 
 ## Vector

--- a/docs/modules/graphics.md
+++ b/docs/modules/graphics.md
@@ -95,22 +95,22 @@ A value between `0 - 255` to represent the alpha transparency channel.
 ### Default Palette
 The values for the colors in this palette can be found [here](https://www.romanzolotarev.com/pico-8-color-palette/).
 
-#### `static black: Color
-#### `static darkblue : Color
-#### `static darkpurple: Color
-#### `static darkgreen: Color
-#### `static brown: Color
-#### `static darkgray: Color
-#### `static lightgray: Color
-#### `static white: Color
-#### `static red: Color
-#### `static orange: Color
-#### `static yellow: Color
-#### `static green: Color
-#### `static blue: Color
-#### `static indigo: Color
-#### `static pink: Color
-#### `static peach: Color
+#### `static black: Color`
+#### `static darkblue : Color`
+#### `static darkpurple: Color`
+#### `static darkgreen: Color`
+#### `static brown: Color`
+#### `static darkgray: Color`
+#### `static lightgray: Color`
+#### `static white: Color`
+#### `static red: Color`
+#### `static orange: Color`
+#### `static yellow: Color`
+#### `static green: Color`
+#### `static blue: Color`
+#### `static indigo: Color`
+#### `static pink: Color`
+#### `static peach: Color`
 
 ## Drawable
 Represents an object which can be drawn to the screen. Objects which conform to this interface can be passed to `Canvas.draw(drawable, x, y)`.

--- a/docs/modules/graphics.md
+++ b/docs/modules/graphics.md
@@ -114,7 +114,9 @@ Draw the image at the given `(x, y)` position on the screen.
 Draw a subsection of the image, defined by the rectangle `(srcX, srcY)` to `(srcX + srcW, srcY + srcH)`. The resulting section is placed at `(destX, destY)`.
 
 #### `transform(parameterMap): Drawable`
-This returns a `Drawable` which will perform the specified transforms, allowing for more fine-grained control over how images are drawn. Options available are:
+This returns a `Drawable` which will perform the specified transforms, allowing for more fine-grained control over how images are drawn. You can store the returned drawable and reuse it across frames, while the image is loaded.
+
+Options available are:
 
  * `srcX`, `srcY` - These specify the top-left corner of the source image region you wish to draw.
  * `srcW`, `srcH` - This is the width and height of the source image region you want to draw.

--- a/docs/modules/graphics.md
+++ b/docs/modules/graphics.md
@@ -123,6 +123,22 @@ This returns a `Drawable` which will perform the specified transforms, allowing 
 
 Transforms are applied as follows: Crop to the region, then rotate, then scale/flip.
 
+Here is an example:
+```wren
+spriteSheet.transform({
+  "srcX": 8, "srcY": 8,
+  "srcW": 8, "srcH": 8,
+  "scaleX": 2,
+  "scaleY": -2,
+  "angle": 90
+}).draw(x, y)
+```
+The code snippet above:
+ * crops an 8x8 tile from a spritesheet, starting from (8, 8) in it's image data
+ * It then rotates it 90 degrees clockwise
+ * Finally, it scales the tile up by 2 in both the X and Y direction, but it flips the tile vertically.
+
+
 
 ## Vector
 

--- a/docs/modules/graphics.md
+++ b/docs/modules/graphics.md
@@ -67,21 +67,36 @@ If `c` isn't provided, we default to black.
 
 ## Color
 
-An instance of the `Color` class represents a single color which can be used for drawing.
+An instance of the `Color` class represents a single color which can be used for drawing to the `Canvas`.
+DOME comes built in with the PICO-8 palette, but you can also define and use your own colors in your games.
+
+### Constructors
 
 #### `construct new(r: Number, g: Number, b: Number)`
-#### `construct new(r: Number, g: Number, b: Number, a: Number)`
-#### `static rgb(r: Number, g: Number, b: Number, a: Number): Color`
+Create a new color with the given RGB values between `0 - 255`, and an alpha value of `255`.
 
-#### `static black: Color`
-#### `static blue: Color`
-#### `static cyan: Color`
-#### `static darkgray: Color`
-#### `static green: Color`
-#### `static lightgray: Color`
-#### `static orange: Color`
-#### `static red: Color`
-#### `static white: Color`
+#### `construct new(r: Number, g: Number, b: Number, a: Number)`
+Create a new color with the given RGBA values between `0 - 255`.
+
+### Default Palette
+The values for the colors in this palette can be found [here](https://www.romanzolotarev.com/pico-8-color-palette/).
+
+#### `static black: Color
+#### `static darkblue : Color
+#### `static darkpurple: Color
+#### `static darkgreen: Color
+#### `static brown: Color
+#### `static darkgray: Color
+#### `static lightgray: Color
+#### `static white: Color
+#### `static red: Color
+#### `static orange: Color
+#### `static yellow: Color
+#### `static green: Color
+#### `static blue: Color
+#### `static indigo: Color
+#### `static pink: Color
+#### `static peach: Color
 
 ## Drawable
 Represents an object which can be drawn to the screen. Objects which conform to this interface can be passed to `Canvas.draw(drawable, x, y)`.

--- a/examples/spaceshooter/main.wren
+++ b/examples/spaceshooter/main.wren
@@ -195,7 +195,11 @@ class Ship {
   draw(t) {
     var frame = (t / 5).floor % 2
     if (_health > 0 && !_imm || (_t/4).floor % 2 == 0) {
-      Canvas.draw(_ship[frame], _x, _y)
+      Canvas.draw(_ship[frame].transform({
+        "angle": 180,
+        "scaleX": 2,
+        "scaleY": 2
+      }), _x, _y)
     }
 
   }

--- a/examples/spaceshooter/main.wren
+++ b/examples/spaceshooter/main.wren
@@ -195,11 +195,7 @@ class Ship {
   draw(t) {
     var frame = (t / 5).floor % 2
     if (_health > 0 && !_imm || (_t/4).floor % 2 == 0) {
-      Canvas.draw(_ship[frame].transform({
-        "angle": 180,
-        "scaleX": 2,
-        "scaleY": 2
-      }), _x, _y)
+      Canvas.draw(_ship[frame], _x, _y)
     }
 
   }

--- a/src/math.c
+++ b/src/math.c
@@ -3,6 +3,10 @@
  */
 
 typedef struct {
+  int32_t x;
+  int32_t y;
+} iVEC;
+typedef struct {
   double x;
   double y;
 } VEC;

--- a/src/math.c
+++ b/src/math.c
@@ -1,6 +1,46 @@
 /*
  math.c
  */
+
+typedef struct {
+  double x;
+  double y;
+} VEC;
+
+double VEC_len(VEC v) {
+  return sqrt(pow(v.x, 2) + pow(v.y, 2));
+
+}
+
+VEC VEC_add(VEC v1, VEC v2) {
+  VEC result = { v1.x + v2.x, v1.y + v2.y };
+  return result;
+}
+VEC VEC_sub(VEC v1, VEC v2) {
+  VEC result = { v1.x - v2.x, v1.y - v2.y };
+  return result;
+}
+VEC VEC_scale(VEC v, double s) {
+  VEC result = { v.x * s, v.y * s };
+  return result;
+}
+
+VEC VEC_neg(VEC v) {
+  return VEC_scale(v, -1);
+}
+
+double VEC_dot(VEC v1, VEC v2) {
+  return v1.x * v2.x + v1.y * v2.y;
+}
+
+VEC VEC_perp(VEC v) {
+  VEC result = { -v.y , v.x };
+  return result;
+}
+
+
+
+
 double max(double n1, double n2) {
   if (n1 > n2) {
     return n1;

--- a/src/modules/graphics.wren
+++ b/src/modules/graphics.wren
@@ -3,7 +3,7 @@
   The graphics module provides all the system functions required for drawing to the screen.
 */
 import "vector" for Point, Vec, Vector
-import "image" for ImageData
+import "image" for Drawable, ImageData
 
 /**
     @Class Canvas
@@ -136,7 +136,7 @@ class Canvas {
   foreign static height
 
   static draw(object, x, y) {
-    if (object is ImageData) {
+    if (object is Drawable) {
       object.draw(x, y)
     }
   }

--- a/src/modules/graphics.wren
+++ b/src/modules/graphics.wren
@@ -162,15 +162,22 @@ class Color {
 
   rgb { Color.rgb(_r, _g, _b, _a) }
 
-  static white { AllColors["white"] }
   static black { AllColors["black"] }
-  static red { AllColors["red"] }
-  static orange { AllColors["orange"] }
-  static blue { AllColors["blue"] }
-  static green { AllColors["green"] }
-  static cyan { AllColors["cyan"] }
+  static darkblue { AllColors["darkblue"] }
+  static darkpurple { AllColors["darkpurple"] }
+  static darkgreen { AllColors["darkgreen"] }
+  static brown { AllColors["brown"] }
   static darkgray { AllColors["darkgray"] }
   static lightgray { AllColors["lightgray"] }
+  static white { AllColors["white"] }
+  static red { AllColors["red"] }
+  static orange { AllColors["orange"] }
+  static yellow { AllColors["yellow"] }
+  static green { AllColors["green"] }
+  static blue { AllColors["blue"] }
+  static indigo { AllColors["indigo"] }
+  static pink { AllColors["pink"] }
+  static peach { AllColors["peach"] }
 
   static rgb(r, g, b, a) {
     return a << 24 | r << 16 | g << 8 | b
@@ -179,15 +186,20 @@ class Color {
 
 var AllColors = {
   "black": Color.new(0, 0, 0),
-  "white": Color.new(255, 255, 255),
-  "orange": Color.new(255, 163, 0),
-  "red": Color.new(255, 0, 0),
-  "green": Color.new(0, 255, 0),
-  "blue": Color.new(0, 0, 255),
-  "cyan": Color.new(0, 255, 255),
-  "magenta": Color.new(255, 0, 255),
-  "yellow": Color.new(255, 255, 0),
+  "darkblue": Color.new(29, 43, 83),
+  "darkpurple": Color.new(126, 37, 83),
+  "darkgreen": Color.new(0, 135, 81),
+  "brown": Color.new(171, 82, 54),
+  "darkgray": Color.new(95, 87, 79),
   "lightgray": Color.new(194, 195, 199),
-  "darkgray": Color.new(95, 87, 79)
+  "white": Color.new(255, 255, 255),
+  "red": Color.new(255, 0, 77),
+  "orange": Color.new(255, 163, 0),
+  "yellow": Color.new(255, 236, 39),
+  "green": Color.new(0, 228, 54),
+  "blue": Color.new(41, 173, 255),
+  "indigo": Color.new(131, 118, 156),
+  "pink": Color.new(255, 119, 168),
+  "peach": Color.new(255, 204, 170)
 }
 

--- a/src/modules/graphics.wren
+++ b/src/modules/graphics.wren
@@ -3,6 +3,7 @@
   The graphics module provides all the system functions required for drawing to the screen.
 */
 import "vector" for Point, Vec, Vector
+import "image" for ImageData
 
 /**
     @Class Canvas
@@ -188,29 +189,5 @@ var AllColors = {
   "yellow": Color.new(255, 255, 0),
   "lightgray": Color.new(194, 195, 199),
   "darkgray": Color.new(95, 87, 79)
-}
-
-foreign class ImageData {
-  // This constructor is private
-  construct initFromFile(data) {}
-
-  static loadFromFile(path) {
-    if (!__cache) {
-      __cache = {}
-    }
-
-    if (!__cache.containsKey(path)) {
-      import "io" for FileSystem
-      var data = FileSystem.load(path)
-      __cache[path] = ImageData.initFromFile(data)
-    }
-
-    return __cache[path]
-  }
-  foreign draw(x, y)
-  foreign drawArea(srcX, srcY, srcW, srcH, destX, destY)
-
-  foreign width
-  foreign height
 }
 

--- a/src/modules/graphics.wren
+++ b/src/modules/graphics.wren
@@ -160,7 +160,14 @@ class Color {
     _a = a
   }
 
-  rgb { Color.rgb(_r, _g, _b, _a) }
+  rgb {
+    return a << 24 | r << 16 | g << 8 | b
+  }
+
+  a { _a }
+  r { _r }
+  g { _g }
+  b { _b }
 
   static black { AllColors["black"] }
   static darkblue { AllColors["darkblue"] }
@@ -178,10 +185,6 @@ class Color {
   static indigo { AllColors["indigo"] }
   static pink { AllColors["pink"] }
   static peach { AllColors["peach"] }
-
-  static rgb(r, g, b, a) {
-    return a << 24 | r << 16 | g << 8 | b
-  }
 }
 
 var AllColors = {

--- a/src/modules/image.c
+++ b/src/modules/image.c
@@ -106,13 +106,13 @@ DRAW_COMMAND_execute(ENGINE* engine, DRAW_COMMAND* commandPtr) {
   double areaMaxX = max(point1x, max(point2x, point3x));
   double areaMaxY = max(point1y, max(point2y, point3y));
 
-  double areaHeight = areaMaxY - areaMinY;// mid(0.0, srcH, image->height);
-  double areaWidth = areaMaxX - areaMinX;// mid(0.0, srcW, image->width);
+  double areaHeight = areaMaxY - areaMinY;
+  double areaWidth = areaMaxX - areaMinX;
 
   double boundsX, boundsY;
   if (angle90 < 0) {
-    boundsY = fabs(scaleY) + 2.0;
-    boundsX = fabs(scaleX) + 2.0;
+    boundsY = fabs(scaleY);
+    boundsX = fabs(scaleX);
   } else {
     boundsY = 0;
     boundsX = 0;
@@ -133,16 +133,8 @@ DRAW_COMMAND_execute(ENGINE* engine, DRAW_COMMAND* commandPtr) {
       int32_t u = srcX + floor((q) * c * sX + (t) * s * sY + (srcW / 2.0));
       int32_t v = srcY + floor((t) * c * sY - (q) * s * sX + (srcH / 2.0));
 
-      // Make sure we are in the selected bounds
-      /*
-      if (u < srcX || u > srcX + srcW || v < srcY || v > srcY + srcH) {
-        continue;
-      }
-      */
-
       // protect against invalid memory access
       if (v < 0 || v >= image->height || u < 0 || u >= image->width) {
-        printf("continue\n");
         continue;
       }
 

--- a/src/modules/image.c
+++ b/src/modules/image.c
@@ -74,8 +74,8 @@ DRAW_COMMAND_execute(ENGINE* engine, DRAW_COMMAND* commandPtr) {
     sX = fabs(sX);
     sY = fabs(sY);
 
-    int32_t w = srcW * fabs(scale.x);
-    int32_t h = srcH * fabs(scale.y);
+    int32_t w = (srcW) * fabs(scale.x);
+    int32_t h = (srcH) * fabs(scale.y);
 
     if (direction & 1) {
       swap = w;
@@ -95,12 +95,12 @@ DRAW_COMMAND_execute(ENGINE* engine, DRAW_COMMAND* commandPtr) {
         int32_t v = (t);
 
         if ((scale.y > 0 && direction >= 2) || (scale.y < 0 && direction < 2)) {
-          y = dest.y + h - j;
+          y = dest.y + (h-1) - j;
         }
 
         bool flipX = ((direction == 1 || direction == 2));
         if ((scale.x < 0 && !flipX) || (scale.x > 0 && flipX)) {
-          x = dest.x + w - i;
+          x = dest.x + (w-1) - i;
         }
 
         if (direction & 1) {

--- a/src/modules/image.c
+++ b/src/modules/image.c
@@ -238,7 +238,6 @@ void IMAGE_finalize(void* data) {
   if (image->pixels != NULL) {
     stbi_image_free(image->pixels);
   }
-
 }
 
 void IMAGE_getWidth(WrenVM* vm) {
@@ -249,37 +248,4 @@ void IMAGE_getWidth(WrenVM* vm) {
 void IMAGE_getHeight(WrenVM* vm) {
   IMAGE* image = (IMAGE*)wrenGetSlotForeign(vm, 0);
   wrenSetSlotDouble(vm, 0, image->height);
-}
-
-void IMAGE_drawArea(WrenVM* vm) {
-  ASSERT_SLOT_TYPE(vm, 1, NUM, "source x");
-  ASSERT_SLOT_TYPE(vm, 2, NUM, "source y");
-  ASSERT_SLOT_TYPE(vm, 3, NUM, "source width");
-  ASSERT_SLOT_TYPE(vm, 4, NUM, "source height");
-  ASSERT_SLOT_TYPE(vm, 5, NUM, "destination x");
-  ASSERT_SLOT_TYPE(vm, 6, NUM, "destination y");
-
-  IMAGE* image = (IMAGE*)wrenGetSlotForeign(vm, 0);
-  DRAW_COMMAND command = DRAW_COMMAND_init(image);
-
-  command.src.x = wrenGetSlotDouble(vm, 1);
-  command.src.y = wrenGetSlotDouble(vm, 2);
-  command.srcW = wrenGetSlotDouble(vm, 3);
-  command.srcH = wrenGetSlotDouble(vm, 4);
-  command.dest.x = wrenGetSlotDouble(vm, 5);
-  command.dest.y = wrenGetSlotDouble(vm, 6);
-
-  ENGINE* engine = (ENGINE*)wrenGetUserData(vm);
-  DRAW_COMMAND_execute(engine, &command);
-}
-
-void IMAGE_draw(WrenVM* vm) {
-  ASSERT_SLOT_TYPE(vm, 1, NUM, "x");
-  ASSERT_SLOT_TYPE(vm, 2, NUM, "y");
-  ENGINE* engine = (ENGINE*)wrenGetUserData(vm);
-  IMAGE* image = (IMAGE*)wrenGetSlotForeign(vm, 0);
-  DRAW_COMMAND command = DRAW_COMMAND_init(image);
-  command.dest.x = wrenGetSlotDouble(vm, 1);
-  command.dest.y = wrenGetSlotDouble(vm, 2);
-  DRAW_COMMAND_execute(engine, &command);
 }

--- a/src/modules/image.c
+++ b/src/modules/image.c
@@ -5,6 +5,20 @@ typedef struct {
   uint32_t* pixels;
 } IMAGE;
 
+enum { DRAW_MODE_RGBA, DRAW_MODE_MONO } DRAW_MODE;
+
+typedef struct {
+  IMAGE* image;
+  bool flipVertical;
+  bool flipHorizontal;
+  bool rotate;
+
+  DRAW_MODE mode;
+  // MONO colours
+  uint32_t background;
+  uint32_t foreground;
+} DRAW_COMMAND;
+
 void IMAGE_allocate(WrenVM* vm) {
 
   ASSERT_SLOT_TYPE(vm, 1, STRING, "image");

--- a/src/modules/image.c
+++ b/src/modules/image.c
@@ -123,18 +123,18 @@ void IMAGE_drawArea(WrenVM* vm) {
   double areaHeight = mid(0.0, srcH, image->height);
   double areaWidth = mid(0.0, srcW, image->width);
 
-  double angle = 0.0;
+  double angle = 90.0;
   double theta = M_PI * (angle / 180.0);
   double c = cos(-theta);
   double s = sin(-theta);
 
-  double scaleX = 2.0;
-  double scaleY = 2.0;
+  double scaleX = -2.0;
+  double scaleY = 4.0;
   double sX = (1.0 / scaleX);
   double sY = (1.0 / scaleY);
 
-  double w = srcW / 2.0;
-  double h = srcH / 2.0;
+  double w = fabs(scaleX) * (srcW) / 2.0;
+  double h = fabs(scaleY) * (srcH) / 2.0;
 
   uint32_t* pixel = (uint32_t*)image->pixels;
   for (int32_t j = 0; j < ceil(fabs(scaleY)*areaHeight); j++) {
@@ -142,23 +142,15 @@ void IMAGE_drawArea(WrenVM* vm) {
       int32_t x = destX + i;
       int32_t y = destY + j;
 
-      int32_t u = i;
-      int32_t v = j;
+      int32_t q = i - w;
+      int32_t t = j - h;
 
+      int32_t u = srcX + (c * q * sX - s * t * sY) + w * fabs(sX);
+      int32_t v = srcY + (s * q * sX + c * t * sY) + h * fabs(sY);
 
-      u = srcX + ((i - w)*c + (j - h)*s)*sX + w*sX;
-      v = srcY + (-(i - w)*s + (j - h)*c)*sY + h*sY;
+      // u = round(srcX + ((i - w)*c + (j - h)*s)*sX + w*sX);
+      // v = round(srcY + (-(i - w)*s + (j - h)*c)*sY + h*sY);
 
-
-      if (v < srcY || v >= srcY+srcH || u < srcX || u >= srcX+srcW) {
-        //continue;
-      }
-
-      /*
-      if (v < srcY || v >= srcY + areaHeight || u < srcX || u >= srcX + areaWidth) {
-        continue;
-      }
-      */
       if (v < 0 || v >= image->height || u < 0 || u >= image->width) {
         continue;
       }

--- a/src/modules/image.c
+++ b/src/modules/image.c
@@ -172,6 +172,23 @@ DRAW_COMMAND_allocate(WrenVM* vm) {
     wrenGetListElement(vm, 2, 6, 1);
     ASSERT_SLOT_TYPE(vm, 1, NUM, "source height");
     command->srcH = wrenGetSlotDouble(vm, 1);
+
+    wrenGetListElement(vm, 2, 7, 1);
+    ASSERT_SLOT_TYPE(vm, 1, STRING, "color mode");
+    char* mode = wrenGetSlotString(vm, 1);
+    if (STRINGS_EQUAL(mode, "MONO")) {
+      command->mode = COLOR_MODE_MONO;
+    } else {
+      command->mode = COLOR_MODE_RGBA;
+    }
+
+    wrenGetListElement(vm, 2, 8, 1);
+    ASSERT_SLOT_TYPE(vm, 1, NUM, "foreground color");
+    command->foregroundColor = wrenGetSlotDouble(vm, 1);
+
+    wrenGetListElement(vm, 2, 9, 1);
+    ASSERT_SLOT_TYPE(vm, 1, NUM, "background color");
+    command->backgroundColor = wrenGetSlotDouble(vm, 1);
   }
 }
 

--- a/src/modules/image.c
+++ b/src/modules/image.c
@@ -120,29 +120,46 @@ void IMAGE_drawArea(WrenVM* vm) {
   int32_t destY = wrenGetSlotDouble(vm, 6);
   ENGINE* engine = (ENGINE*)wrenGetUserData(vm);
 
-  double areaHeight = mid(0, srcH, image->height);
-  double areaWidth = mid(0, srcW, image->width);
+  double areaHeight = mid(0.0, srcH, image->height);
+  double areaWidth = mid(0.0, srcW, image->width);
 
-  double theta = M_PI * (45 / 180.0);
-  int8_t c = round(cos(-theta));
-  int8_t s = round(sin(-theta));
+  double angle = 0.0;
+  double theta = M_PI * (angle / 180.0);
+  double c = cos(-theta);
+  double s = sin(-theta);
 
-  uint32_t w = round(srcW / 2.0);
-  uint32_t h = round(srcH / 2.0);
+  double scaleX = 2.0;
+  double scaleY = 2.0;
+  double sX = (1.0 / scaleX);
+  double sY = (1.0 / scaleY);
+
+  double w = srcW / 2.0;
+  double h = srcH / 2.0;
 
   uint32_t* pixel = (uint32_t*)image->pixels;
-  for (int32_t j = 0; j < areaHeight; j++) {
-    for (int32_t i = 0; i < areaWidth; i++) {
-      uint32_t x = destX + i;
-      uint32_t y = destY + j;
+  for (int32_t j = 0; j < ceil(fabs(scaleY)*areaHeight); j++) {
+    for (int32_t i = 0; i < ceil(fabs(scaleX)*areaWidth); i++) {
+      int32_t x = destX + i;
+      int32_t y = destY + j;
 
       int32_t u = i;
       int32_t v = j;
 
-      u = srcX + (i - w)*c - (j - h)*s + w;
-      v = srcY + (i - w)*s + (j - h)*c + h;
+
+      u = srcX + ((i - w)*c + (j - h)*s)*sX + w*sX;
+      v = srcY + (-(i - w)*s + (j - h)*c)*sY + h*sY;
+
 
       if (v < srcY || v >= srcY+srcH || u < srcX || u >= srcX+srcW) {
+        //continue;
+      }
+
+      /*
+      if (v < srcY || v >= srcY + areaHeight || u < srcX || u >= srcX + areaWidth) {
+        continue;
+      }
+      */
+      if (v < 0 || v >= image->height || u < 0 || u >= image->width) {
         continue;
       }
       uint32_t c = pixel[v * image->width + u];

--- a/src/modules/image.c
+++ b/src/modules/image.c
@@ -123,13 +123,13 @@ void IMAGE_drawArea(WrenVM* vm) {
   double areaHeight = mid(0.0, srcH, image->height);
   double areaWidth = mid(0.0, srcW, image->width);
 
-  double angle = 90.0;
+  double angle = 30.0;
   double theta = M_PI * (angle / 180.0);
   double c = cos(-theta);
   double s = sin(-theta);
 
-  double scaleX = -2.0;
-  double scaleY = 4.0;
+  double scaleX = 2.0;
+  double scaleY = 2.0;
   double sX = (1.0 / scaleX);
   double sY = (1.0 / scaleY);
 
@@ -147,9 +147,9 @@ void IMAGE_drawArea(WrenVM* vm) {
 
       int32_t u = srcX + (c * q * sX - s * t * sY) + w * fabs(sX);
       int32_t v = srcY + (s * q * sX + c * t * sY) + h * fabs(sY);
-
-      // u = round(srcX + ((i - w)*c + (j - h)*s)*sX + w*sX);
-      // v = round(srcY + (-(i - w)*s + (j - h)*c)*sY + h*sY);
+      if (u < srcX || u > srcX + srcW || v < srcY || v > srcY + srcH) {
+        continue;
+      }
 
       if (v < 0 || v >= image->height || u < 0 || u >= image->width) {
         continue;

--- a/src/modules/image.c
+++ b/src/modules/image.c
@@ -9,17 +9,14 @@ typedef enum { COLOR_MODE_RGBA, COLOR_MODE_MONO } COLOR_MODE;
 
 typedef struct {
   IMAGE* image;
-  double scaleX;
-  double scaleY;
+  VEC scale;
   double angle;
 
-  int32_t srcX;
-  int32_t srcY;
   int32_t srcW;
   int32_t srcH;
 
-  int32_t destX;
-  int32_t destY;
+  iVEC src;
+  VEC dest;
 
   COLOR_MODE mode;
   // MONO colour palette
@@ -31,16 +28,13 @@ DRAW_COMMAND DRAW_COMMAND_init(IMAGE* image) {
   DRAW_COMMAND command;
   command.image = image;
 
-  command.srcX = 0;
-  command.srcY = 0;
+  command.src = (iVEC) { 0, 0 };
   command.srcW = image->width;
   command.srcH = image->height;
-  command.destX = 0;
-  command.destY = 0;
+  command.dest = (VEC) { 0, 0 };
 
   command.angle = 0;
-  command.scaleX = 1;
-  command.scaleY = 1;
+  command.scale = (VEC) { 1, 1 };
 
   command.mode = COLOR_MODE_RGBA;
   command.backgroundColor = 0xFF000000;
@@ -55,42 +49,35 @@ DRAW_COMMAND_execute(ENGINE* engine, DRAW_COMMAND* commandPtr) {
   DRAW_COMMAND command = *commandPtr;
   IMAGE* image = command.image;
 
-  int32_t srcX = command.srcX;
-  int32_t srcY = command.srcY;
+  iVEC src = command.src;
   int32_t srcW = command.srcW;
   int32_t srcH = command.srcH;
 
-  int32_t destX = command.destX;
-  int32_t destY = command.destY;
+  VEC dest = command.dest;
 
   double angle = command.angle;
-  double scaleX = command.scaleX;
-  double scaleY = command.scaleY;
+  VEC scale = command.scale;
 
   uint32_t* pixel = (uint32_t*)image->pixels;
-  pixel = pixel + srcY * image->width + srcX;
+  pixel = pixel + (src.y * image->width + src.x);
 
 
-  int angle90 = (int)(angle/90);
-  if(angle90 == angle/90) { /* if the angle is a multiple of 90 degrees */
-    angle90 %= 4;
-    if(angle90 < 0) angle90 += 4;
-  } else {
-    angle90 = -1;
-  }
+  int direction = round(angle / 90);
+  direction %= 4;
+  if(direction < 0) direction += 4;
 
-  double sX = (1.0 / scaleX);
-  double sY = (1.0 / scaleY);
+  double sX = (1.0 / scale.x);
+  double sY = (1.0 / scale.y);
 
-  if (angle90 >= 0) {
+  if (direction >= 0) {
     double swap;
     sX = fabs(sX);
     sY = fabs(sY);
 
-    int32_t w = srcW * fabs(scaleX);
-    int32_t h = srcH * fabs(scaleY);
+    int32_t w = srcW * fabs(scale.x);
+    int32_t h = srcH * fabs(scale.y);
 
-    if (angle90 & 1) {
+    if (direction & 1) {
       swap = w;
       w = h;
       h = swap;
@@ -98,8 +85,8 @@ DRAW_COMMAND_execute(ENGINE* engine, DRAW_COMMAND* commandPtr) {
     for (int32_t j = 0; j < ceil(h); j++) {
       for (int32_t i = 0; i < ceil(w); i++) {
 
-        int32_t x = destX + i;
-        int32_t y = destY + j;
+        int32_t x = dest.x + i;
+        int32_t y = dest.y + j;
 
         double q = i * sX;
         double t = j * sY;
@@ -107,16 +94,16 @@ DRAW_COMMAND_execute(ENGINE* engine, DRAW_COMMAND* commandPtr) {
         int32_t u = (q);
         int32_t v = (t);
 
-        if ((scaleY > 0 && angle90 >= 2) || (scaleY < 0 && angle90 < 2)) {
-          y = destY + h - j;
+        if ((scale.y > 0 && direction >= 2) || (scale.y < 0 && direction < 2)) {
+          y = dest.y + h - j;
         }
 
-        bool flipX = ((angle90 == 1 || angle90 == 2));
-        if ((scaleX < 0 && !flipX) || (scaleX > 0 && flipX)) {
-          x = destX + w - i;
+        bool flipX = ((direction == 1 || direction == 2));
+        if ((scale.x < 0 && !flipX) || (scale.x > 0 && flipX)) {
+          x = dest.x + w - i;
         }
 
-        if (angle90 & 1) {
+        if (direction & 1) {
           swap = u;
           u = v;
           v = swap;
@@ -130,70 +117,6 @@ DRAW_COMMAND_execute(ENGINE* engine, DRAW_COMMAND* commandPtr) {
           ENGINE_pset(engine, x, y, 0xFFFF00FF);
           continue;
         }
-        uint32_t color = pixel[v * image->width + u];
-        if (command.mode == COLOR_MODE_MONO) {
-          uint8_t alpha = (0xFF000000 & color) >> 24;
-          if (alpha < 0xFF || (color & 0x00FFFFFF) == 0) {
-            color = command.backgroundColor;
-          } else {
-            color = command.foregroundColor;
-          }
-        }
-        ENGINE_pset(engine, x, y, color);
-      }
-    }
-  } else {
-    double theta = M_PI * (angle / 180.0);
-    double c = cos(theta);
-    double s = sin(theta);
-
-    double point1x = -srcH * s;
-    double point1y = srcH * c;
-
-    double point2x = srcW * c - srcH * s;
-    double point2y = srcH * c + srcW * s;
-
-    double point3x = srcW * c;
-    double point3y = srcW * s;
-
-    double areaMinX = min(0, min(point1x, min(point2x, point3x)));
-    double areaMinY = min(0, min(point1y, min(point2y, point3y)));
-    double areaMaxX = max(point1x, max(point2x, point3x));
-    double areaMaxY = max(point1y, max(point2y, point3y));
-
-    double areaHeight = fabs(areaMaxY - areaMinY);
-    double areaWidth = fabs(areaMaxX - areaMinX);
-
-    // Debug output
-    printf("x: %f, %f, %f\n", point1x, point2x, point3x);
-    printf("y: %f, %f, %f\n", point1y, point2y, point3y);
-    printf("o: %i, %i\n", srcW, srcH);
-    printf("min: %f, %f\n", areaMinX, areaMinY);
-    printf("max: %f, %f\n", areaMaxX, areaMaxY);
-
-    // Overscan
-    double boundsY = fabs(scaleY);
-    double boundsX = fabs(scaleX);
-
-    for (int32_t j = -boundsY; j < ceil(fabs(scaleY) * areaHeight) + boundsY; j++) {
-      for (int32_t i = -boundsX; i < ceil(fabs(scaleX) * areaWidth) + boundsX; i++) {
-        int32_t x = destX + i;
-        int32_t y = destY + j;
-
-        double q = i - (fabs(scaleX) * areaWidth / 2.0);
-        double t = j - (fabs(scaleY) * areaHeight / 2.0);
-
-        int32_t u = floor((q) * c * sX + (t) * s * sY + (srcW / 2.0));
-        int32_t v = floor((t) * c * sY - (q) * s * sX + (srcH / 2.0));
-
-        if (u < 0 || u > srcW || v < 0 || v > srcH) {
-          continue;
-        }
-        // protect against invalid memory access
-        if (v < 0 || v >= image->height || u < 0 || u >= image->width) {
-          continue;
-        }
-
         uint32_t color = pixel[v * image->width + u];
         if (command.mode == COLOR_MODE_MONO) {
           uint8_t alpha = (0xFF000000 & color) >> 24;
@@ -226,21 +149,21 @@ DRAW_COMMAND_allocate(WrenVM* vm) {
   command->angle = wrenGetSlotDouble(vm, 1);
 
   wrenGetListElement(vm, 2, 1, 1);
-  ASSERT_SLOT_TYPE(vm, 1, NUM, "scaleX");
-  command->scaleX = wrenGetSlotDouble(vm, 1);
+  ASSERT_SLOT_TYPE(vm, 1, NUM, "scale.x");
+  command->scale.x = wrenGetSlotDouble(vm, 1);
 
   wrenGetListElement(vm, 2, 2, 1);
-  ASSERT_SLOT_TYPE(vm, 1, NUM, "scaleY");
-  command->scaleY = wrenGetSlotDouble(vm, 1);
+  ASSERT_SLOT_TYPE(vm, 1, NUM, "scale.y");
+  command->scale.y = wrenGetSlotDouble(vm, 1);
 
   if (wrenGetListCount(vm, 2) > 3) {
     wrenGetListElement(vm, 2, 3, 1);
     ASSERT_SLOT_TYPE(vm, 1, NUM, "source X");
-    command->srcX = wrenGetSlotDouble(vm, 1);
+    command->src.x = wrenGetSlotDouble(vm, 1);
 
     wrenGetListElement(vm, 2, 4, 1);
     ASSERT_SLOT_TYPE(vm, 1, NUM, "source Y");
-    command->srcY = wrenGetSlotDouble(vm, 1);
+    command->src.y = wrenGetSlotDouble(vm, 1);
 
     wrenGetListElement(vm, 2, 5, 1);
     ASSERT_SLOT_TYPE(vm, 1, NUM, "source width");
@@ -265,8 +188,8 @@ DRAW_COMMAND_draw(WrenVM* vm) {
   ENGINE* engine = (ENGINE*)wrenGetUserData(vm);
   DRAW_COMMAND* command = wrenGetSlotForeign(vm, 0);
 
-  command->destX = wrenGetSlotDouble(vm, 1);
-  command->destY = wrenGetSlotDouble(vm, 2);
+  command->dest.x = wrenGetSlotDouble(vm, 1);
+  command->dest.y = wrenGetSlotDouble(vm, 2);
 
   DRAW_COMMAND_execute(engine, command);
 }
@@ -339,12 +262,12 @@ void IMAGE_drawArea(WrenVM* vm) {
   IMAGE* image = (IMAGE*)wrenGetSlotForeign(vm, 0);
   DRAW_COMMAND command = DRAW_COMMAND_init(image);
 
-  command.srcX = wrenGetSlotDouble(vm, 1);
-  command.srcY = wrenGetSlotDouble(vm, 2);
+  command.src.x = wrenGetSlotDouble(vm, 1);
+  command.src.y = wrenGetSlotDouble(vm, 2);
   command.srcW = wrenGetSlotDouble(vm, 3);
   command.srcH = wrenGetSlotDouble(vm, 4);
-  command.destX = wrenGetSlotDouble(vm, 5);
-  command.destY = wrenGetSlotDouble(vm, 6);
+  command.dest.x = wrenGetSlotDouble(vm, 5);
+  command.dest.y = wrenGetSlotDouble(vm, 6);
 
   ENGINE* engine = (ENGINE*)wrenGetUserData(vm);
   DRAW_COMMAND_execute(engine, &command);
@@ -356,7 +279,7 @@ void IMAGE_draw(WrenVM* vm) {
   ENGINE* engine = (ENGINE*)wrenGetUserData(vm);
   IMAGE* image = (IMAGE*)wrenGetSlotForeign(vm, 0);
   DRAW_COMMAND command = DRAW_COMMAND_init(image);
-  command.destX = wrenGetSlotDouble(vm, 1);
-  command.destY = wrenGetSlotDouble(vm, 2);
+  command.dest.x = wrenGetSlotDouble(vm, 1);
+  command.dest.y = wrenGetSlotDouble(vm, 2);
   DRAW_COMMAND_execute(engine, &command);
 }

--- a/src/modules/image.c
+++ b/src/modules/image.c
@@ -123,12 +123,12 @@ void IMAGE_drawArea(WrenVM* vm) {
   double areaHeight = mid(0, srcH, image->height);
   double areaWidth = mid(0, srcW, image->width);
 
-  double theta = M_PI * (90 / 180.0);
+  double theta = M_PI * (45 / 180.0);
   int8_t c = round(cos(-theta));
   int8_t s = round(sin(-theta));
 
-  uint32_t w = srcW / 2;
-  uint32_t h = srcH / 2;
+  uint32_t w = round(srcW / 2.0);
+  uint32_t h = round(srcH / 2.0);
 
   uint32_t* pixel = (uint32_t*)image->pixels;
   for (int32_t j = 0; j < areaHeight; j++) {
@@ -136,13 +136,17 @@ void IMAGE_drawArea(WrenVM* vm) {
       uint32_t x = destX + i;
       uint32_t y = destY + j;
 
-      uint32_t u = i;
-      uint32_t v = j;
+      int32_t u = i;
+      int32_t v = j;
 
       u = srcX + (i - w)*c - (j - h)*s + w;
       v = srcY + (i - w)*s + (j - h)*c + h;
 
+      if (v < srcY || v >= srcY+srcH || u < srcX || u >= srcX+srcW) {
+        continue;
+      }
       uint32_t c = pixel[v * image->width + u];
+
       ENGINE_pset(engine, x, y, c);
     }
   }

--- a/src/modules/image.c
+++ b/src/modules/image.c
@@ -85,8 +85,10 @@ void IMAGE_draw(WrenVM* vm) {
   uint32_t y = wrenGetSlotDouble(vm, 2);
 
   uint32_t* pixel = (uint32_t*)image->pixels;
-  for (int j = 0; j < image->height; j++) {
-    for (int i = 0; i < image->width; i++) {
+  for (int32_t j = 0; j < image->height; j++) {
+    for (int32_t i = 0; i < image->width; i++) {
+
+
       uint32_t c = pixel[j * image->width + i];
       ENGINE_pset(engine, x+i, y+j, c);
     }
@@ -122,8 +124,8 @@ void IMAGE_drawArea(WrenVM* vm) {
   double areaWidth = mid(0, srcW, image->width);
 
   uint32_t* pixel = (uint32_t*)image->pixels;
-  for (int j = 0; j < areaHeight; j++) {
-    for (int i = 0; i < areaWidth; i++) {
+  for (int32_t j = 0; j < areaHeight; j++) {
+    for (int32_t i = 0; i < areaWidth; i++) {
       uint32_t c = pixel[(srcY+j) * image->width + (srcX+i)];
       ENGINE_pset(engine, destX+i, destY+j, c);
     }

--- a/src/modules/image.c
+++ b/src/modules/image.c
@@ -110,7 +110,9 @@ DRAW_COMMAND_execute(ENGINE* engine, DRAW_COMMAND* commandPtr) {
         if ((scaleY > 0 && angle90 >= 2) || (scaleY < 0 && angle90 < 2)) {
           y = destY + h - j;
         }
-        if (angle90 == 1 || angle90 == 2) {
+
+        bool flipX = ((angle90 == 1 || angle90 == 2));
+        if ((scaleX < 0 && !flipX) || (scaleX > 0 && flipX)) {
           x = destX + w - i;
         }
 

--- a/src/modules/image.c
+++ b/src/modules/image.c
@@ -92,10 +92,6 @@ DRAW_COMMAND_execute(ENGINE* engine, DRAW_COMMAND* commandPtr) {
     s = sin(theta);
   }
 
-  double sX = (1.0 / scaleX);
-  double sY = (1.0 / scaleY);
-
-
   double point1x = -srcH * s;
   double point1y = srcH * c;
 
@@ -113,26 +109,29 @@ DRAW_COMMAND_execute(ENGINE* engine, DRAW_COMMAND* commandPtr) {
   double areaHeight = areaMaxY - areaMinY;// mid(0.0, srcH, image->height);
   double areaWidth = areaMaxX - areaMinX;// mid(0.0, srcW, image->width);
 
-  double w = (fabs(scaleX) * (srcW) / 2.0);
-  double h = (fabs(scaleY) * (srcH) / 2.0) - 0.5;
-  w = (fabs(scaleX) * areaWidth / 2.0) + 0.5;
-  h = (fabs(scaleY) * areaHeight / 2.0) + 0.5;
-
-  if (angle < 360 && angle > 180.0) {
-    printf("%f, %f\n", areaWidth, areaHeight);
+  double boundsX, boundsY;
+  if (angle90 < 0) {
+    boundsY = fabs(scaleY) + 2.0;
+    boundsX = fabs(scaleX) + 2.0;
+  } else {
+    boundsY = 0;
+    boundsX = 0;
   }
 
+  double sX = (1.0 / scaleX);
+  double sY = (1.0 / scaleY);
+
   uint32_t* pixel = (uint32_t*)image->pixels;
-  for (int32_t j = -1; j <= ceil(areaHeight); j++) {
-    for (int32_t i = -1; i <= ceil(areaWidth); i++) {
+  for (int32_t j = -boundsY; j < ceil(fabs(scaleY) * areaHeight) + boundsY; j++) {
+    for (int32_t i = -boundsX; i < ceil(fabs(scaleX) * areaWidth) + boundsX; i++) {
       int32_t x = destX + i;
       int32_t y = destY + j;
 
-      double q = i - (areaWidth/2.0);
-      double t = j - (areaHeight/2.0);
+      double q = i - (fabs(scaleX) * areaWidth / 2.0);
+      double t = j - (fabs(scaleY) * areaHeight / 2.0);
 
-      int32_t u = srcX + round((q) * c + (t) * s + (srcW / 2.0));
-      int32_t v = srcY + round((t) * c - (q) * s + (srcH / 2.0));
+      int32_t u = srcX + floor((q) * c * sX + (t) * s * sY + (srcW / 2.0));
+      int32_t v = srcY + floor((t) * c * sY - (q) * s * sX + (srcH / 2.0));
 
       // Make sure we are in the selected bounds
       /*
@@ -143,6 +142,7 @@ DRAW_COMMAND_execute(ENGINE* engine, DRAW_COMMAND* commandPtr) {
 
       // protect against invalid memory access
       if (v < 0 || v >= image->height || u < 0 || u >= image->width) {
+        printf("continue\n");
         continue;
       }
 

--- a/src/modules/image.c
+++ b/src/modules/image.c
@@ -85,8 +85,8 @@ DRAW_COMMAND DRAW_COMMAND_init(IMAGE* image) {
   command.destX = 0;
   command.destY = 0;
 
-  command.angle = 0;
-  command.scaleX = 2;
+  command.angle = 90;
+  command.scaleX = -2;
   command.scaleY = 2;
 
   command.mode = COLOR_MODE_MONO;
@@ -131,8 +131,8 @@ void IMAGE_drawCommand(ENGINE* engine, DRAW_COMMAND command) {
   double sX = (1.0 / scaleX);
   double sY = (1.0 / scaleY);
 
-  double w = fabs(scaleX) * (srcW) / 2.0;
-  double h = fabs(scaleY) * (srcH) / 2.0;
+  double w = (fabs(scaleX) * (srcW) / 2.0) - 0.5;
+  double h = (fabs(scaleY) * (srcH) / 2.0) - 0.5;
 
   uint32_t* pixel = (uint32_t*)image->pixels;
   for (int32_t j = 0; j < ceil(fabs(scaleY)*areaHeight); j++) {
@@ -143,8 +143,9 @@ void IMAGE_drawCommand(ENGINE* engine, DRAW_COMMAND command) {
       double q = i - w;
       double t = j - h;
 
-      int32_t u = floor(srcX + (c * q * sX - s * t * sY) + w * fabs(sX));
-      int32_t v = floor(srcY + (s * q * sX + c * t * sY) + h * fabs(sY));
+      int32_t u = srcX + ((c * q * sX - s * t * sY) + w * fabs(sX));
+      int32_t v = srcY + ((s * q * sX + c * t * sY) + h * fabs(sY));
+
       if (u < srcX || u > srcX + srcW || v < srcY || v > srcY + srcH) {
         continue;
       }

--- a/src/modules/image.c
+++ b/src/modules/image.c
@@ -5,7 +5,7 @@ typedef struct {
   uint32_t* pixels;
 } IMAGE;
 
-enum { DRAW_MODE_RGBA, DRAW_MODE_MONO } DRAW_MODE;
+typedef enum { COLOR_MODE_RGBA, COLOR_MODE_MONO } COLOR_MODE;
 
 typedef struct {
   IMAGE* image;
@@ -13,8 +13,16 @@ typedef struct {
   bool flipHorizontal;
   bool rotate;
 
-  DRAW_MODE mode;
-  // MONO colours
+  int32_t sourceX;
+  int32_t sourceY;
+  int32_t sourceWidth;
+  int32_t sourceHeight;
+
+  int32_t destX;
+  int32_t destY;
+
+  COLOR_MODE mode;
+  // MONO colour palette
   uint32_t background;
   uint32_t foreground;
 } DRAW_COMMAND;

--- a/src/modules/image.c
+++ b/src/modules/image.c
@@ -123,11 +123,27 @@ void IMAGE_drawArea(WrenVM* vm) {
   double areaHeight = mid(0, srcH, image->height);
   double areaWidth = mid(0, srcW, image->width);
 
+  double theta = M_PI * (90 / 180.0);
+  int8_t c = round(cos(-theta));
+  int8_t s = round(sin(-theta));
+
+  uint32_t w = srcW / 2;
+  uint32_t h = srcH / 2;
+
   uint32_t* pixel = (uint32_t*)image->pixels;
   for (int32_t j = 0; j < areaHeight; j++) {
     for (int32_t i = 0; i < areaWidth; i++) {
-      uint32_t c = pixel[(srcY+j) * image->width + (srcX+i)];
-      ENGINE_pset(engine, destX+i, destY+j, c);
+      uint32_t x = destX + i;
+      uint32_t y = destY + j;
+
+      uint32_t u = i;
+      uint32_t v = j;
+
+      u = srcX + (i - w)*c - (j - h)*s + w;
+      v = srcY + (i - w)*s + (j - h)*c + h;
+
+      uint32_t c = pixel[v * image->width + u];
+      ENGINE_pset(engine, x, y, c);
     }
   }
 }

--- a/src/modules/image.c
+++ b/src/modules/image.c
@@ -161,17 +161,19 @@ DRAW_COMMAND_execute(ENGINE* engine, DRAW_COMMAND* commandPtr) {
     double areaMaxX = max(point1x, max(point2x, point3x));
     double areaMaxY = max(point1y, max(point2y, point3y));
 
-    double areaHeight = areaMaxY - areaMinY;
-    double areaWidth = areaMaxX - areaMinX;
+    double areaHeight = fabs(areaMaxY - areaMinY);
+    double areaWidth = fabs(areaMaxX - areaMinX);
 
-    double boundsX, boundsY;
-    if (angle90 < 0) {
-      boundsY = fabs(scaleY);
-      boundsX = fabs(scaleX);
-    } else {
-      boundsY = 0;
-      boundsX = 0;
-    }
+    // Debug output
+    printf("x: %f, %f, %f\n", point1x, point2x, point3x);
+    printf("y: %f, %f, %f\n", point1y, point2y, point3y);
+    printf("o: %i, %i\n", srcW, srcH);
+    printf("min: %f, %f\n", areaMinX, areaMinY);
+    printf("max: %f, %f\n", areaMaxX, areaMaxY);
+
+    // Overscan
+    double boundsY = fabs(scaleY);
+    double boundsX = fabs(scaleX);
 
     for (int32_t j = -boundsY; j < ceil(fabs(scaleY) * areaHeight) + boundsY; j++) {
       for (int32_t i = -boundsX; i < ceil(fabs(scaleX) * areaWidth) + boundsX; i++) {

--- a/src/modules/image.wren
+++ b/src/modules/image.wren
@@ -40,10 +40,14 @@ foreign class ImageData is Drawable {
 
     return __cache[path]
   }
-  foreign draw(x, y)
   transform(map) {
     return DrawCommand.parse(this, map)
   }
+
+  draw(x, y) {
+    return this.transform({}).draw(x, y)
+  }
+
   drawArea(srcX, srcY, srcW, srcH, destX, destY) {
     return this.transform({
       "srcX": srcX,

--- a/src/modules/image.wren
+++ b/src/modules/image.wren
@@ -6,11 +6,16 @@ foreign class DrawCommand is Drawable {
   construct new(image, params) {}
 
   static parse(image, map) {
-    return DrawCommand.new(image, [
+    var list = [
       map["angle"] || 0,
       map["scaleX"] || 1,
-      map["scaleY"] || 1
-    ])
+      map["scaleY"] || 1,
+      map["srcX"] || 0,
+      map["srcY"] || 0,
+      map["srcW"] || image.width,
+      map["srcH"] || image.height,
+    ]
+    return DrawCommand.new(image, list)
   }
 
   foreign draw(x, y)
@@ -39,7 +44,14 @@ foreign class ImageData is Drawable {
   transform(map) {
     return DrawCommand.parse(this, map)
   }
-  foreign drawArea(srcX, srcY, srcW, srcH, destX, destY)
+  drawArea(srcX, srcY, srcW, srcH, destX, destY) {
+    return this.transform({
+      "srcX": srcX,
+      "srcY": srcY,
+      "srcW": srcW,
+      "srcH": srcH
+    }).draw(destX, destY)
+  }
 
   foreign width
   foreign height

--- a/src/modules/image.wren
+++ b/src/modules/image.wren
@@ -1,0 +1,24 @@
+foreign class ImageData {
+  // This constructor is private
+  construct initFromFile(data) {}
+
+  static loadFromFile(path) {
+    if (!__cache) {
+      __cache = {}
+    }
+
+    if (!__cache.containsKey(path)) {
+      import "io" for FileSystem
+      var data = FileSystem.load(path)
+      __cache[path] = ImageData.initFromFile(data)
+    }
+
+    return __cache[path]
+  }
+  foreign draw(x, y)
+  foreign drawArea(srcX, srcY, srcW, srcH, destX, destY)
+
+  foreign width
+  foreign height
+}
+

--- a/src/modules/image.wren
+++ b/src/modules/image.wren
@@ -1,3 +1,5 @@
+var NULL_TRANSFORM = {}
+
 class Drawable {
   draw(x, y) {}
 }
@@ -45,7 +47,7 @@ foreign class ImageData is Drawable {
   }
 
   draw(x, y) {
-    return this.transform({}).draw(x, y)
+    return this.transform(NULL_TRANSFORM).draw(x, y)
   }
 
   drawArea(srcX, srcY, srcW, srcH, destX, destY) {

--- a/src/modules/image.wren
+++ b/src/modules/image.wren
@@ -16,6 +16,7 @@ foreign class ImageData {
     return __cache[path]
   }
   foreign draw(x, y)
+  foreign transform(map)
   foreign drawArea(srcX, srcY, srcW, srcH, destX, destY)
 
   foreign width

--- a/src/modules/image.wren
+++ b/src/modules/image.wren
@@ -1,4 +1,24 @@
-foreign class ImageData {
+class Drawable {
+  draw(x, y) {}
+}
+
+foreign class DrawCommand is Drawable {
+  construct new(image, params) {}
+
+  static parse(image, map) {
+    return DrawCommand.new(image, [
+      map["angle"] || 0,
+      map["scaleX"] || 1,
+      map["scaleY"] || 1
+    ])
+  }
+
+  foreign draw(x, y)
+
+}
+
+
+foreign class ImageData is Drawable {
   // This constructor is private
   construct initFromFile(data) {}
 
@@ -16,7 +36,9 @@ foreign class ImageData {
     return __cache[path]
   }
   foreign draw(x, y)
-  foreign transform(map)
+  transform(map) {
+    return DrawCommand.parse(this, map)
+  }
   foreign drawArea(srcX, srcY, srcW, srcH, destX, destY)
 
   foreign width

--- a/src/modules/image.wren
+++ b/src/modules/image.wren
@@ -1,3 +1,4 @@
+
 var NULL_TRANSFORM = {}
 
 class Drawable {
@@ -8,6 +9,7 @@ foreign class DrawCommand is Drawable {
   construct new(image, params) {}
 
   static parse(image, map) {
+    import "graphics" for Color
     var list = [
       map["angle"] || 0,
       map["scaleX"] || 1,
@@ -16,6 +18,9 @@ foreign class DrawCommand is Drawable {
       map["srcY"] || 0,
       map["srcW"] || image.width,
       map["srcH"] || image.height,
+      map["mode"] || "RGBA",
+      (map["foreground"] || Color.white).rgb,
+      (map["background"] || Color.black).rgb
     ]
     return DrawCommand.new(image, list)
   }

--- a/src/util/generateEmbedModules.sh
+++ b/src/util/generateEmbedModules.sh
@@ -8,6 +8,7 @@ declare -a arr=(
 "io"
 "audio"
 "vector"
+"image"
 )
  
 declare -a opts=(

--- a/src/vm.c
+++ b/src/vm.c
@@ -26,7 +26,7 @@ VM_bind_foreign_class(WrenVM* vm, const char* module, const char* className) {
     }
   }
   #endif
-  if (STRINGS_EQUAL(module, "graphics")) {
+  if (STRINGS_EQUAL(module, "image")) {
     if (STRINGS_EQUAL(className, "ImageData")) {
       methods.allocate = IMAGE_allocate;
       methods.finalize = IMAGE_finalize;
@@ -171,10 +171,12 @@ internal WrenVM* VM_create(ENGINE* engine) {
   MAP_add(&engine->fnMap, "graphics", "Canvas", "f_resize(_,_,_)", true, CANVAS_resize);
   MAP_add(&engine->fnMap, "graphics", "Canvas", "width", true, CANVAS_getWidth);
   MAP_add(&engine->fnMap, "graphics", "Canvas", "height", true, CANVAS_getHeight);
-  MAP_add(&engine->fnMap, "graphics", "ImageData", "draw(_,_)", false, IMAGE_draw);
-  MAP_add(&engine->fnMap, "graphics", "ImageData", "width", false, IMAGE_getWidth);
-  MAP_add(&engine->fnMap, "graphics", "ImageData", "height", false, IMAGE_getHeight);
-  MAP_add(&engine->fnMap, "graphics", "ImageData", "drawArea(_,_,_,_,_,_)", false, IMAGE_drawArea);
+
+  // Image
+  MAP_add(&engine->fnMap, "image", "ImageData", "draw(_,_)", false, IMAGE_draw);
+  MAP_add(&engine->fnMap, "image", "ImageData", "width", false, IMAGE_getWidth);
+  MAP_add(&engine->fnMap, "image", "ImageData", "height", false, IMAGE_getHeight);
+  MAP_add(&engine->fnMap, "image", "ImageData", "drawArea(_,_,_,_,_,_)", false, IMAGE_drawArea);
 
   // Audio
   MAP_add(&engine->fnMap, "audio", "SystemChannel", "enabled=(_)", false, AUDIO_CHANNEL_setEnabled);

--- a/src/vm.c
+++ b/src/vm.c
@@ -30,6 +30,9 @@ VM_bind_foreign_class(WrenVM* vm, const char* module, const char* className) {
     if (STRINGS_EQUAL(className, "ImageData")) {
       methods.allocate = IMAGE_allocate;
       methods.finalize = IMAGE_finalize;
+    } else if (STRINGS_EQUAL(className, "DrawCommand")) {
+      methods.allocate = DRAW_COMMAND_allocate;
+      methods.finalize = DRAW_COMMAND_finalize;
     }
   } else if (STRINGS_EQUAL(module, "io")) {
     if (STRINGS_EQUAL(className, "DataBuffer")) {
@@ -177,7 +180,8 @@ internal WrenVM* VM_create(ENGINE* engine) {
   MAP_add(&engine->fnMap, "image", "ImageData", "width", false, IMAGE_getWidth);
   MAP_add(&engine->fnMap, "image", "ImageData", "height", false, IMAGE_getHeight);
   MAP_add(&engine->fnMap, "image", "ImageData", "drawArea(_,_,_,_,_,_)", false, IMAGE_drawArea);
-  MAP_add(&engine->fnMap, "image", "ImageData", "transform(_)", false, IMAGE_transform);
+  // MAP_add(&engine->fnMap, "image", "ImageData", "transform(_)", false, IMAGE_transform);
+  MAP_add(&engine->fnMap, "image", "DrawCommand", "draw(_,_)", false, DRAW_COMMAND_draw);
 
   // Audio
   MAP_add(&engine->fnMap, "audio", "SystemChannel", "enabled=(_)", false, AUDIO_CHANNEL_setEnabled);

--- a/src/vm.c
+++ b/src/vm.c
@@ -177,6 +177,7 @@ internal WrenVM* VM_create(ENGINE* engine) {
   MAP_add(&engine->fnMap, "image", "ImageData", "width", false, IMAGE_getWidth);
   MAP_add(&engine->fnMap, "image", "ImageData", "height", false, IMAGE_getHeight);
   MAP_add(&engine->fnMap, "image", "ImageData", "drawArea(_,_,_,_,_,_)", false, IMAGE_drawArea);
+  MAP_add(&engine->fnMap, "image", "ImageData", "transform(_)", false, IMAGE_transform);
 
   // Audio
   MAP_add(&engine->fnMap, "audio", "SystemChannel", "enabled=(_)", false, AUDIO_CHANNEL_setEnabled);

--- a/src/vm.c
+++ b/src/vm.c
@@ -176,11 +176,8 @@ internal WrenVM* VM_create(ENGINE* engine) {
   MAP_add(&engine->fnMap, "graphics", "Canvas", "height", true, CANVAS_getHeight);
 
   // Image
-  MAP_add(&engine->fnMap, "image", "ImageData", "draw(_,_)", false, IMAGE_draw);
   MAP_add(&engine->fnMap, "image", "ImageData", "width", false, IMAGE_getWidth);
   MAP_add(&engine->fnMap, "image", "ImageData", "height", false, IMAGE_getHeight);
-  MAP_add(&engine->fnMap, "image", "ImageData", "drawArea(_,_,_,_,_,_)", false, IMAGE_drawArea);
-  // MAP_add(&engine->fnMap, "image", "ImageData", "transform(_)", false, IMAGE_transform);
   MAP_add(&engine->fnMap, "image", "DrawCommand", "draw(_,_)", false, DRAW_COMMAND_draw);
 
   // Audio


### PR DESCRIPTION
After a lot of back and forth, this is the least-error-prone approach to rotation/scaling:

- Rotation can only happen at 90 degree increments.
- Negative scaling is equivalent to flipping.
- Flipping occurs after rotation.
- Images are rotated and fixed to the top-left corner, so they should appear to rotate "in place", if the image is square.