### PR TITLE
Gif record

### DIFF
--- a/examples/spaceshooter/main.wren
+++ b/examples/spaceshooter/main.wren
@@ -25,13 +25,13 @@ class Box {
 class Game {
   static init() {
     Window.title = "Example Game"
-    System.print(Window.title)
     __state = MainGame
     __state.init()
 
     __settingsFile = FileSystem.load("config.txt")
     System.print(__settingsFile)
   }
+
   static update() {
 
     __x = Mouse.x
@@ -43,8 +43,8 @@ class Game {
       __state.init()
     }
     Mouse.hidden = Mouse.isButtonPressed("right")
-    System.print(Mouse.hidden)
   }
+
   static draw(dt) {
     __state.draw(dt)
     if (Mouse.isButtonPressed("right")) {

--- a/src/engine.c
+++ b/src/engine.c
@@ -670,7 +670,7 @@ ENGINE_drawDebug(ENGINE* engine) {
 
 internal bool
 ENGINE_canvasResize(ENGINE* engine, uint32_t newWidth, uint32_t newHeight, uint32_t color) {
-  if (engine->record.makeGif) {
+  if (engine->initialized && engine->record.makeGif) {
     return true;
   }
   if (engine->width == newWidth && engine->height == newHeight) {

--- a/src/engine.h
+++ b/src/engine.h
@@ -37,6 +37,7 @@ typedef struct {
   bool lockstep;
   int exit_status;
   struct AUDIO_ENGINE_t* audioEngine;
+  bool initialized;
   bool debugEnabled;
   bool vsyncEnabled;
   ENGINE_DEBUG debug;

--- a/src/engine.h
+++ b/src/engine.h
@@ -15,10 +15,14 @@ typedef struct {
 } ENGINE_DEBUG;
 
 typedef struct {
-  SDL_sem* record;
+  bool makeGif;
   void* gifPixels;
   volatile bool frameReady;
   char* gifName;
+} ENGINE_RECORDER;
+
+typedef struct {
+  ENGINE_RECORDER record;
   SDL_Window* window;
   SDL_Renderer *renderer;
   SDL_Texture *texture;

--- a/src/engine.h
+++ b/src/engine.h
@@ -15,6 +15,10 @@ typedef struct {
 } ENGINE_DEBUG;
 
 typedef struct {
+  SDL_sem* record;
+  void* gifPixels;
+  volatile bool frameReady;
+  char* gifName;
   SDL_Window* window;
   SDL_Renderer *renderer;
   SDL_Texture *texture;

--- a/src/main.c
+++ b/src/main.c
@@ -346,6 +346,7 @@ int main(int argc, char* args[])
     result = EXIT_FAILURE;
     goto vm_cleanup;
   }
+  engine.initialized = true;
 
 
   SDL_ShowWindow(engine.window);

--- a/src/modules/graphics.wren
+++ b/src/modules/graphics.wren
@@ -161,7 +161,7 @@ class Color {
   }
 
   rgb {
-    return a << 24 | r << 16 | g << 8 | b
+    return a << 24 | b << 16 | g << 8 | r
   }
 
   a { _a }

--- a/src/modules/image.c
+++ b/src/modules/image.c
@@ -108,6 +108,8 @@ DRAW_COMMAND_execute(ENGINE* engine, DRAW_COMMAND* commandPtr) {
           u = v;
           v = swap;
         }
+
+        /*
         if (u < 0 || u > srcW || v < 0 || v > srcH) {
           continue;
         }
@@ -117,7 +119,8 @@ DRAW_COMMAND_execute(ENGINE* engine, DRAW_COMMAND* commandPtr) {
           ENGINE_pset(engine, x, y, 0xFFFF00FF);
           continue;
         }
-        uint32_t color = pixel[v * image->width + u];
+        */
+        uint32_t color = *(pixel + (v * image->width + u));
         if (command.mode == COLOR_MODE_MONO) {
           uint8_t alpha = (0xFF000000 & color) >> 24;
           if (alpha < 0xFF || (color & 0x00FFFFFF) == 0) {
@@ -237,18 +240,6 @@ void IMAGE_allocate(WrenVM* vm) {
     return;
   }
   uint32_t* pixel = (uint32_t*)image->pixels;
-  /*
-  for (int i = 0; i < image->height * image->width; i++) {
-    uint32_t c = *pixel;
-
-    uint8_t r = (0x000000FF & c);
-    uint8_t g = (0x0000FF00 & c) >> 8;
-    uint8_t b = (0x00FF0000 & c) >> 16;
-    uint8_t a = (0xFF000000 & c) >> 24;
-    *pixel = (a << 24) | (b << 16) | (g << 8) | r;
-    pixel++;
-  }
-  */
 }
 
 void IMAGE_finalize(void* data) {

--- a/src/modules/image.c
+++ b/src/modules/image.c
@@ -237,6 +237,7 @@ void IMAGE_allocate(WrenVM* vm) {
     return;
   }
   uint32_t* pixel = (uint32_t*)image->pixels;
+  /*
   for (int i = 0; i < image->height * image->width; i++) {
     uint32_t c = *pixel;
 
@@ -244,9 +245,10 @@ void IMAGE_allocate(WrenVM* vm) {
     uint8_t g = (0x0000FF00 & c) >> 8;
     uint8_t b = (0x00FF0000 & c) >> 16;
     uint8_t a = (0xFF000000 & c) >> 24;
-    *pixel = (a << 24) | (r << 16) | (g << 8) | b;
+    *pixel = (a << 24) | (b << 16) | (g << 8) | r;
     pixel++;
   }
+  */
 }
 
 void IMAGE_finalize(void* data) {


### PR DESCRIPTION
The current gif recording system (`--record=gifName.gif`) is rather intensive on the main thread, so this PR offloads the file IO and pixel-channel-rearrangement to its own thread.

Unfortunately, it still struggles to keep a good frame-rate, depending on the size of the canvas and number of colours in use, so I don't recommend it for serious work.