### PR TITLE
Added properties Window.width and Window.height

### DIFF
--- a/docs/modules/dome.md
+++ b/docs/modules/dome.md
@@ -1,41 +1,57 @@
 [< Back](.)
 
-dome
-================
+# dome
 
 The `dome` module allows you to control various aspects of how DOME as an application operates.
 
 It contains the following classes:
 
-* [Process](#process)
-* [Window](#window)
+- [Process](#process)
+- [Window](#window)
 
 ## Process
 
 ### Static Methods
 
 #### `static exit(): Void`
+
 #### `static exit(code: Number): Void`
+
 Allows you to programmatically close DOME. This command behaves a little differently based on whether an error code is provided (defaults to `0`):
- * If `code` is `0`, then this will immediately shutdown DOME in a graceful manner, but no other Wren code will execute after this call.
- * Otherwise, the current Fiber will be aborted, the game loop will exit and DOME will shutdown.
+
+- If `code` is `0`, then this will immediately shutdown DOME in a graceful manner, but no other Wren code will execute after this call.
+- Otherwise, the current Fiber will be aborted, the game loop will exit and DOME will shutdown.
 
 ## Window
 
 ### Static Fields
 
 #### `static fullscreen: Boolean`
+
 Set this to switch between Windowed and Fullscreen modes.
 
 #### `static lockstep: Boolean`
+
 Setting this to true will disable "catch up" game loop behaviour. This is useful for lighter games, or on systems where you experience a little stuttering at 60fps.
+
 #### `static title: String`
+
 This allows you to set and get the title of the DOME window.
+
 #### `static vsync: String`
+
 Setting this to true will make the renderer wait for VSync before presenting to the display. Changing this value is an expensive operation and so shouldn't be done frequently.
+
+#### `static height: Number`
+
+This is the height of the window/viewport, in pixels.
+
+#### `static width: Number`
+
+This is the width of the window/viewport, in pixels.
 
 ### Static Methods
 
-
 #### `static resize(width: Number, height: Number): Void`
+
 This allows you to control the size of DOME's window. The viewport will scale accordingly, but the canvas will NOT resize.

--- a/docs/modules/dome.md
+++ b/docs/modules/dome.md
@@ -30,6 +30,10 @@ Allows you to programmatically close DOME. This command behaves a little differe
 
 Set this to switch between Windowed and Fullscreen modes.
 
+#### `static height: Number`
+
+This is the height of the window/viewport, in pixels.
+
 #### `static lockstep: Boolean`
 
 Setting this to true will disable "catch up" game loop behaviour. This is useful for lighter games, or on systems where you experience a little stuttering at 60fps.
@@ -41,10 +45,6 @@ This allows you to set and get the title of the DOME window.
 #### `static vsync: String`
 
 Setting this to true will make the renderer wait for VSync before presenting to the display. Changing this value is an expensive operation and so shouldn't be done frequently.
-
-#### `static height: Number`
-
-This is the height of the window/viewport, in pixels.
 
 #### `static width: Number`
 

--- a/src/modules/dome.c
+++ b/src/modules/dome.c
@@ -22,7 +22,7 @@ WINDOW_resize(WrenVM* vm) {
 internal void
 WINDOW_getWidth(WrenVM* vm) {
   ENGINE* engine = (ENGINE*)wrenGetUserData(vm);
-  uint32_t width = 0;
+  int width = 0;
   SDL_GetWindowSize(engine->window, &width, NULL);
   wrenSetSlotDouble(vm, 0, width);
 }
@@ -30,7 +30,7 @@ WINDOW_getWidth(WrenVM* vm) {
 internal void
 WINDOW_getHeight(WrenVM* vm) {
   ENGINE* engine = (ENGINE*)wrenGetUserData(vm);
-  uint32_t height = 0;
+  int height = 0;
   SDL_GetWindowSize(engine->window, NULL, &height);
   wrenSetSlotDouble(vm, 0, height);
 }

--- a/src/modules/dome.c
+++ b/src/modules/dome.c
@@ -20,6 +20,22 @@ WINDOW_resize(WrenVM* vm) {
 }
 
 internal void
+WINDOW_getWidth(WrenVM* vm) {
+  ENGINE* engine = (ENGINE*)wrenGetUserData(vm);
+  uint32_t width = 0;
+  SDL_GetWindowSize(engine->window, &width, NULL);
+  wrenSetSlotDouble(vm, 0, width);
+}
+
+internal void
+WINDOW_getHeight(WrenVM* vm) {
+  ENGINE* engine = (ENGINE*)wrenGetUserData(vm);
+  uint32_t height = 0;
+  SDL_GetWindowSize(engine->window, NULL, &height);
+  wrenSetSlotDouble(vm, 0, height);
+}
+
+internal void
 WINDOW_setTitle(WrenVM* vm) {
   ENGINE* engine = (ENGINE*)wrenGetUserData(vm);
   ASSERT_SLOT_TYPE(vm, 1, STRING, "title");

--- a/src/modules/dome.wren
+++ b/src/modules/dome.wren
@@ -17,6 +17,8 @@ class Window {
   foreign static lockstep=(value)
   foreign static fullscreen=(value)
   foreign static fullscreen
+  foreign static width
+  foreign static height
 
   foreign static resize(width, height)
 }

--- a/src/vm.c
+++ b/src/vm.c
@@ -181,6 +181,8 @@ internal WrenVM* VM_create(ENGINE* engine) {
   MAP_addFunction(&engine->moduleMap, "dome", "static Window.title", WINDOW_getTitle);
   MAP_addFunction(&engine->moduleMap, "dome", "static Window.fullscreen=(_)", WINDOW_setFullscreen);
   MAP_addFunction(&engine->moduleMap, "dome", "static Window.fullscreen", WINDOW_getFullscreen);
+  MAP_addFunction(&engine->moduleMap, "graphics", "static Window.width", WINDOW_getWidth);
+  MAP_addFunction(&engine->moduleMap, "graphics", "static Winow.height", WINDOW_getHeight);
 
 #if DOME_OPT_FFI
   // FFI

--- a/src/vm.c
+++ b/src/vm.c
@@ -181,8 +181,8 @@ internal WrenVM* VM_create(ENGINE* engine) {
   MAP_addFunction(&engine->moduleMap, "dome", "static Window.title", WINDOW_getTitle);
   MAP_addFunction(&engine->moduleMap, "dome", "static Window.fullscreen=(_)", WINDOW_setFullscreen);
   MAP_addFunction(&engine->moduleMap, "dome", "static Window.fullscreen", WINDOW_getFullscreen);
-  MAP_addFunction(&engine->moduleMap, "graphics", "static Window.width", WINDOW_getWidth);
-  MAP_addFunction(&engine->moduleMap, "graphics", "static Winow.height", WINDOW_getHeight);
+  MAP_addFunction(&engine->moduleMap, "dome", "static Window.width", WINDOW_getWidth);
+  MAP_addFunction(&engine->moduleMap, "dome", "static Window.height", WINDOW_getHeight);
 
 #if DOME_OPT_FFI
   // FFI


### PR DESCRIPTION
For completeness.

In dome.c

```c
internal void
WINDOW_getWidth(WrenVM* vm) {
  ENGINE* engine = (ENGINE*)wrenGetUserData(vm);
  int width = 0;
  SDL_GetWindowSize(engine->window, &width, NULL);
  wrenSetSlotDouble(vm, 0, width);
}

internal void
WINDOW_getHeight(WrenVM* vm) {
  ENGINE* engine = (ENGINE*)wrenGetUserData(vm);
  int height = 0;
  SDL_GetWindowSize(engine->window, NULL, &height);
  wrenSetSlotDouble(vm, 0, height);
}
```

Example code
```js
System.print("%(Window.width) %(Window.height)")
```