### PR TITLE
Set Audio Channel position

### DIFF
--- a/docs/modules/audio.md
+++ b/docs/modules/audio.md
@@ -90,7 +90,7 @@ You can read and modify the pan position, as a bounded value between -1.0 and 1.
 
 #### `position: Number`
 This marks the position of the next sample to be loaded into the AudioEngine mix buffer (which happens on a seperate thread).
-You cannot change the position, and it may not change on every frame, depending on the size of the buffer.
+You can set a new position for the channel, but it isn't going to be exact, due to delays in audio processing.
 
 You should divide this by `44100` to get the position in seconds.
 

--- a/src/modules/audio.wren
+++ b/src/modules/audio.wren
@@ -36,6 +36,7 @@ foreign class SystemChannel is AudioChannel {
   foreign length
   foreign soundId
   foreign position
+  foreign position=(v)
 
   foreign state
   foreign state=(value)
@@ -58,7 +59,7 @@ class AudioChannelFacade is AudioChannel {
     _channel = channel
     _length = channel.length
     _soundId = channel.soundId
-    _position = 0
+    _position = null // This is only set by the user
     _volume = 1
     _pan = 0
     _loop = false
@@ -114,7 +115,10 @@ class AudioChannelFacade is AudioChannel {
     _channel.volume = _volume
     _channel.pan = _pan
     _channel.loop = _loop
-    _position = _channel.position
+    if (_position != null) {
+      _channel.position = _position
+      _position = null
+    }
   }
 
   // Private
@@ -122,7 +126,8 @@ class AudioChannelFacade is AudioChannel {
   id { _id }
 
   // Public
-  position { _position }
+  position { _position || _channel.position }
+  position=(v) { _position = v }
   length { _length }
   soundId { _soundId }
   volume { _volume }

--- a/src/vm.c
+++ b/src/vm.c
@@ -228,6 +228,7 @@ internal WrenVM* VM_create(ENGINE* engine) {
   MAP_addFunction(&engine->moduleMap, "audio", "SystemChannel.pan", AUDIO_CHANNEL_getPan);
   MAP_addFunction(&engine->moduleMap, "audio", "SystemChannel.volume", AUDIO_CHANNEL_getVolume);
   MAP_addFunction(&engine->moduleMap, "audio", "SystemChannel.volume=(_)", AUDIO_CHANNEL_setVolume);
+  MAP_addFunction(&engine->moduleMap, "audio", "SystemChannel.position=(_)", AUDIO_CHANNEL_setPosition);
   MAP_addFunction(&engine->moduleMap, "audio", "SystemChannel.state=(_)", AUDIO_CHANNEL_setState);
   MAP_addFunction(&engine->moduleMap, "audio", "SystemChannel.audio=(_)", AUDIO_CHANNEL_setAudio);
   MAP_addFunction(&engine->moduleMap, "audio", "SystemChannel.state", AUDIO_CHANNEL_getState);


### PR DESCRIPTION
During DOMEjam, I added this so you can start an audio channel at a sample position (useful for Rhythm Game Level Editing).