### PR TITLE
Version Module

### DIFF
--- a/docs/modules/dome.md
+++ b/docs/modules/dome.md
@@ -7,6 +7,7 @@ The `dome` module allows you to control various aspects of how DOME as an applic
 It contains the following classes:
 
 - [Process](#process)
+- [Version](#version)
 - [Window](#window)
 
 ## Process
@@ -21,6 +22,28 @@ Allows you to programmatically close DOME. This command behaves a little differe
 
 - If `code` is `0`, then this will immediately shutdown DOME in a graceful manner, but no other Wren code will execute after this call.
 - Otherwise, the current Fiber will be aborted, the game loop will exit and DOME will shutdown.
+
+## Version
+This class provides information about the version of DOME which is currently running. You can use this to check that all the features you require are supported.
+DOME uses semantic versioning, split into a major.minor.patch breakdown.
+
+### Static Fields
+#### `static major: Number`
+The major component of the version number.
+#### `static minor: Number`
+The minor component of the version number.
+#### `static patch: Number`
+The patch component of the version number.
+#### `static toString: String`
+A string containing the complete semantic version of the DOME instance running.
+
+#### `static toList: List<Number>`
+A list of the version components, in `[major, minor, patch]` order.
+
+### Static Methods
+#### `static atLeast(version: String): boolean`
+This takes a version as a string of the form `x.y.z`, and returns true if the current version of DOME is at least that of the version specified.
+
 
 ## Window
 

--- a/src/modules/dome.c
+++ b/src/modules/dome.c
@@ -77,3 +77,16 @@ WINDOW_getFullscreen(WrenVM* vm) {
   uint32_t flags = SDL_GetWindowFlags(engine->window);
   wrenSetSlotBool(vm, 0, (flags & SDL_WINDOW_FULLSCREEN_DESKTOP) != 0);
 }
+
+
+internal void
+VERSION_getString(WrenVM* vm) {
+  size_t len;
+  char* version = DOME_VERSION;
+  for (len = 0; len < strlen(version); len++) {
+    if (version[len] != '.' && !isdigit(version[len])) {
+      break;
+    }
+  }
+  wrenSetSlotBytes(vm, 0, version, len);
+}

--- a/src/modules/dome.wren
+++ b/src/modules/dome.wren
@@ -1,3 +1,48 @@
+class Version {
+  foreign static toString
+
+  static major { this.toList[0] }
+  static minor { this.toList[1] }
+  static patch { this.toList[2] }
+
+  static toList {
+    if (!__list) {
+      __list = toString.split(".").map {|value| Num.fromString(value) }.toList
+    }
+    return __list
+  }
+  static atLeast(version) {
+    var values = version.split(".").map {|value| Num.fromString(value) }.toList
+    var actual = this.toList
+    if (values[0] > actual[0]) {
+      return false
+    }
+    if (values[0] < actual[0]) {
+      return true
+    }
+    if (values.count > 1) {
+      if (values[1] > actual[1]) {
+        return false
+      }
+      if (values[1] < actual[1]) {
+        return true
+      }
+    }
+    if (values.count > 2) {
+      if (values[2] > actual[2]) {
+        return false
+      }
+      if (values[2] < actual[2]) {
+        return true
+      }
+    }
+    return true
+  }
+}
+
+
+
+
 class Process {
   foreign static f_exit(n)
   static exit(n) {

--- a/src/vm.c
+++ b/src/vm.c
@@ -213,6 +213,7 @@ internal WrenVM* VM_create(ENGINE* engine) {
   MAP_addFunction(&engine->moduleMap, "dome", "static Window.fullscreen", WINDOW_getFullscreen);
   MAP_addFunction(&engine->moduleMap, "dome", "static Window.width", WINDOW_getWidth);
   MAP_addFunction(&engine->moduleMap, "dome", "static Window.height", WINDOW_getHeight);
+  MAP_addFunction(&engine->moduleMap, "dome", "static Version.toString", VERSION_getString);
 
 #if DOME_OPT_FFI
   // FFI


### PR DESCRIPTION
Inspired by the work in [#59]

Provides a simple interface for testing the version of DOME being used, although it doesn't support additional labels in the `semver` format. (Eg: `1.2.0-dev`).