### PR TITLE
Upgrade to Wren 0.3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 CC = cc
 EXENAME = dome
 MODE_FILE=.mode
+ARCH_FILE=.arch
 
 SOURCE  = src
 UTILS = $(SOURCE)/util
@@ -10,6 +11,7 @@ MODULES = $(SOURCE)/modules
 EXAMPLES = examples
 
 MODE ?= $(shell cat $(MODE_FILE) 2>/dev/null || echo release)
+ARCH ?= $(shell cat $(ARCH_FILE) 2>/dev/null || echo 64bit)
 BUILD_VALUE=$(shell git rev-parse --short HEAD)
 SYS=$(shell uname -s)
 
@@ -107,7 +109,7 @@ $(LIBS)/libffi.a: $(LIBS)/libffi
 	./setup_ffi.sh
 
 $(LIBS)/libwren.a: $(LIBS)/wren
-	./setup_wren.sh WREN_OPT_RANDOM=$(BUILTIN_RANDOM) WREN_OPT_META=$(BUILTIN_META)
+	./setup_wren.sh $(ARCH) WREN_OPT_RANDOM=$(BUILTIN_RANDOM) WREN_OPT_META=$(BUILTIN_META)
 
 $(INCLUDES)/ffi.h: $(LIBS)/libffi.a
 $(INCLUDES)/ffitarget.h: $(LIBS)/libffi.a

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ EXAMPLES = examples
 
 MODE ?= $(shell cat $(MODE_FILE) 2>/dev/null || echo release)
 ARCH ?= $(shell cat $(ARCH_FILE) 2>/dev/null || echo 64bit)
+$(shell echo $(ARCH) > $(ARCH_FILE))
 BUILD_VALUE=$(shell git rev-parse --short HEAD)
 SYS=$(shell uname -s)
 

--- a/setup_wren.sh
+++ b/setup_wren.sh
@@ -20,4 +20,4 @@ fi
 make clean
 make ${@:2} config=debug_$1 wren && cp ../../lib/libwrend.a ../../../libwrend.a
 make clean
-make ${@:2} MODE=release_$1 wren && cp ../../lib/libwren.a ../../../libwren.a
+make ${@:2} config=release_$1 wren && cp ../../lib/libwren.a ../../../libwren.a

--- a/setup_wren.sh
+++ b/setup_wren.sh
@@ -18,6 +18,6 @@ else
 fi
 
 make clean
-make $@ config=debug_64bit wren && cp ../../lib/libwrend.a ../../../libwrend.a
+make ${@:2} config=debug_$1 wren && cp ../../lib/libwrend.a ../../../libwrend.a
 make clean
-make $@ MODE=release_64bit wren && cp ../../lib/libwren.a ../../../libwren.a
+make ${@:2} MODE=release_$1 wren && cp ../../lib/libwren.a ../../../libwren.a

--- a/setup_wren.sh
+++ b/setup_wren.sh
@@ -1,7 +1,23 @@
 #!/bin/bash
 
-cd src/lib/wren
+cd src/lib/wren/projects
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  # ...
+  cd make
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  cd make.mac
+  # Mac OSX
+elif [[ "$OSTYPE" == "msys" ]]; then
+  cd make
+  # Lightweight shell and GNU utilities compiled for Windows (part of MinGW)
+elif [[ "$OSTYPE" == "win32" ]]; then
+  exit 1
+else
+  exit 1
+fi
+
 make clean
-make $@ MODE=debug vm && cp lib/libwrend.a ../libwrend.a
+make $@ config=debug_64bit wren && cp ../../lib/libwrend.a ../../../libwrend.a
 make clean
-make $@ MODE=release vm && cp lib/libwren.a ../libwren.a
+make $@ MODE=release_64bit wren && cp ../../lib/libwren.a ../../../libwren.a


### PR DESCRIPTION
Wren 0.3.0 made significant changes to its build system, so the DOME build process needed tweaking.

This exposes a certain amount of fragility in the system, so future work should be invested in streamlining the build process.

However, this is sufficient.

Among other changes, this adds an ARCH flag to the make script which can be either `32bit` or `64bit`, in order to build the correct version of `libwren.a`