### PR TITLE
Fix #75: Pan now works at all ranges between -1 and 1

### DIFF
--- a/src/math.c
+++ b/src/math.c
@@ -59,6 +59,25 @@ int64_t min(int64_t n1, int64_t n2) {
   return n2;
 }
 
+double fmid(double n1, double n2, double n3) {
+  double temp;
+  if (n1 > n3) {
+    temp = n1;
+    n1 = n3;
+    n3 = temp;
+  }
+  if (n1 > n2) {
+    temp = n1;
+    n1 = n2;
+    n2 = temp;
+  }
+  if (n2 < n3) {
+    return n2;
+  } else {
+    return n3;
+  }
+}
+
 int64_t mid(int64_t n1, int64_t n2, int64_t n3) {
   int64_t temp;
   if (n1 > n3) {

--- a/src/modules/audio.c
+++ b/src/modules/audio.c
@@ -95,7 +95,7 @@ void AUDIO_ENGINE_mix(void*  userdata,
           float* readCursor = (float*)(audio->buffer);
           readCursor += channel->position * channels;
           float volume = channel->volume;
-          float pan = (channel->pan + 1) * M_PI / 4; // Channel pan is [-1,1] real pan needs to be [0,1]
+          float pan = (channel->pan + 1) * M_PI / 4.0; // Channel pan is [-1,1] real pan needs to be [0,1]
 
           left += readCursor[0] * cos(pan) * volume;
           right += readCursor[1] * sin(pan) * volume;
@@ -408,7 +408,7 @@ internal void AUDIO_CHANNEL_getVolume(WrenVM* vm) {
 internal void AUDIO_CHANNEL_setPan(WrenVM* vm) {
   AUDIO_CHANNEL* channel = (AUDIO_CHANNEL*)wrenGetSlotForeign(vm, 0);
   ASSERT_SLOT_TYPE(vm, 1, NUM, "pan");
-  channel->pan = (float)mid(-1.0, wrenGetSlotDouble(vm, 1), 1.0f);
+  channel->pan = fmid(-1.0, wrenGetSlotDouble(vm, 1), 1.0f);
 }
 
 internal void AUDIO_CHANNEL_getPan(WrenVM* vm) {


### PR DESCRIPTION
Pan was being passed through the `mid` function, which was recently changed to accept integers only. This would lock the pan value to only work at integers of 0, -1 and 1 exactly.