### PR TITLE
Haptics

### DIFF
--- a/docs/modules/input.md
+++ b/docs/modules/input.md
@@ -127,3 +127,5 @@ Valid sides are `left` and `right`.
 Gets the current state of the specified analog stick as a Vector, with `x` and `y` values, which are normalised as values between -1.0 and 1.0.
 Valid sides are `left` and `right`.
 
+#### `rumble(strength: Number, duration: Number): Void`
+If the gamepad is able to vibrate, it will vibrate with a `strength`, clamped between `0.0` and `1.0`, for a `duration` of milliseconds. Rumble and haptic feedback is dependant on platform drivers.

--- a/src/modules/input.c
+++ b/src/modules/input.c
@@ -206,6 +206,9 @@ GAMEPAD_finalize(void* data) {
 
 internal void
 GAMEPAD_rumble(WrenVM* vm) {
+  ASSERT_SLOT_TYPE(vm, 0, FOREIGN, "GamePad");
+  ASSERT_SLOT_TYPE(vm, 1, NUM, "strength");
+  ASSERT_SLOT_TYPE(vm, 2, NUM, "length");
   GAMEPAD* gamepad = wrenGetSlotForeign(vm, 0);
   float strength = fmid(0, wrenGetSlotDouble(vm, 1), 1);
   double length = fmax(0, wrenGetSlotDouble(vm, 2));

--- a/src/modules/input.c
+++ b/src/modules/input.c
@@ -23,6 +23,8 @@ global_variable bool inputCaptured = false;
 internal void
 INPUT_capture(WrenVM* vm) {
   SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER | SDL_INIT_HAPTIC);
+
+  printf("HAPTIC COUNT %i\n", SDL_NumHaptics());
   if (!inputCaptured) {
     wrenGetVariable(vm, "input", "Keyboard", 0);
     keyboardClass = wrenGetSlotHandle(vm, 0);
@@ -177,6 +179,7 @@ GAMEPAD_allocate(WrenVM* vm) {
     SDL_HapticClose(gamepad->haptics);
     gamepad->haptics = NULL;
   }
+  printf("Initialised haptics are %s\n", gamepad->haptics == NULL ? "null" : "ok");
 }
 
 internal void

--- a/src/modules/input.c
+++ b/src/modules/input.c
@@ -24,7 +24,6 @@ internal void
 INPUT_capture(WrenVM* vm) {
   SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER | SDL_INIT_HAPTIC);
 
-  printf("HAPTIC COUNT %i\n", SDL_NumHaptics());
   if (!inputCaptured) {
     wrenGetVariable(vm, "input", "Keyboard", 0);
     keyboardClass = wrenGetSlotHandle(vm, 0);
@@ -175,11 +174,11 @@ GAMEPAD_allocate(WrenVM* vm) {
   gamepad->instanceId = SDL_JoystickInstanceID(joystick);
   gamepad->controller = controller;
   gamepad->haptics = SDL_HapticOpenFromJoystick(joystick);
-  if (SDL_HapticRumbleInit(gamepad->haptics) != 0) {
+  if (SDL_HapticRumbleSupported(gamepad->haptics) == SDL_FALSE
+      || SDL_HapticRumbleInit(gamepad->haptics) != 0) {
     SDL_HapticClose(gamepad->haptics);
     gamepad->haptics = NULL;
   }
-  printf("Initialised haptics are %s\n", gamepad->haptics == NULL ? "null" : "ok");
 }
 
 internal void

--- a/src/modules/input.wren
+++ b/src/modules/input.wren
@@ -111,6 +111,7 @@ foreign class SystemGamePad {
 
   foreign f_getAnalogStick(side)
   foreign getTrigger(side)
+  foreign rumble(strength, length)
 
   getAnalogStick(side) {
     var stick = f_getAnalogStick(side)
@@ -140,6 +141,10 @@ class GamePad {
       _buttons[name] = DigitalInput.init()
     }
     return _buttons[name]
+  }
+
+  rumble(strength, length) {
+    _pad.rumble(strength, length)
   }
 
   isButtonPressed(key) {

--- a/src/vm.c
+++ b/src/vm.c
@@ -307,6 +307,7 @@ internal WrenVM* VM_create(ENGINE* engine) {
   MAP_addFunction(&engine->moduleMap, "input", "SystemGamePad.getTrigger(_)", GAMEPAD_getTrigger);
   MAP_addFunction(&engine->moduleMap, "input", "SystemGamePad.close()", GAMEPAD_close);
   MAP_addFunction(&engine->moduleMap, "input", "SystemGamePad.f_getAnalogStick(_)", GAMEPAD_getAnalogStick);
+  MAP_addFunction(&engine->moduleMap, "input", "SystemGamePad.rumble(_,_)", GAMEPAD_rumble);
   MAP_addFunction(&engine->moduleMap, "input", "SystemGamePad.attached", GAMEPAD_isAttached);
   MAP_addFunction(&engine->moduleMap, "input", "SystemGamePad.name", GAMEPAD_getName);
   MAP_addFunction(&engine->moduleMap, "input", "SystemGamePad.id", GAMEPAD_getId);


### PR DESCRIPTION
`GamePad.rumble(_, _)` is available for compatible gamepads, but will silently fail if there is an incompatibility.