### PR TITLE
Added createDirectory functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ DOME currently depends on a few libraries to achieve it's functions.
 - jo_gif
 - tinydir
 - [ABC_fifo](https://github.com/avivbeeri/abc) (A SPMC threadpool/task dispatching FIFO I wrote for this project)
+- mkdirp
 
 Apart from SDL2, all other dependancies are baked in or linked statically. DOME aspires to be both minimalist and cross platform, so it depends on as few external components as possible.
 

--- a/docs/modules/io.md
+++ b/docs/modules/io.md
@@ -32,3 +32,6 @@ This gives you a safe path where you can write personal game files (saves and se
 #### `static save(path: String, buffer: String): Void`
 Given a valid file `path`, this will create or overwrite the file the data in the `buffer` String object.
 This is a blocking operation, and so execution will stop while the file is saved.
+
+#### `static createDirectory(path: String): Void`
+Given a valid `path`, creates the directory, if it doesn't already exist and makes parent directories as needed.

--- a/src/include/mkdirp/mkdirp.c
+++ b/src/include/mkdirp/mkdirp.c
@@ -1,0 +1,70 @@
+#include <unistd.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "mkdirp.h"
+
+#ifdef _WIN32
+#define PATH_SEPARATOR   '\\'
+#else
+#define PATH_SEPARATOR   '/'
+#endif
+
+char *
+path_normalize(const char *path) {
+    if(!path) return NULL;
+
+    char *copy = strdup(path);
+    if(copy == NULL) return NULL;
+    char *ptr = copy;
+
+    for (int i = 0; copy[i]; ++i) {
+        *ptr++ = path[i];
+        if (path[i] == '/') {
+            ++i;
+            while(path[i] == '/') {
+                --i;
+            }
+        }
+    }
+    *ptr = '\0';
+    return copy;
+}
+
+int
+mkdirp(const char *path, mode_t mode) {
+    char *pathname = NULL;
+    char *parent = NULL;
+
+    if(path == NULL) return -1;
+    pathname = path_normalize(path);
+    if (pathname == NULL) goto fail;
+
+    parent = strdup(pathname);
+    if (parent == NULL) goto fail;
+
+    char *p = parent + strlen(parent);
+    while(PATH_SEPARATOR != *p && p != parent) {
+        --p;
+    }
+    *p = '\0';
+
+    if(p != parent && mkdir(parent, mode != 0)) goto fail;
+    free(parent);
+
+#ifdef _WIN32
+    int rc = mkdir(pathname);
+#else
+    int rc = mkdir(pathname, mode);
+#endif
+
+    free(pathname);
+
+    return rc == 0 || EEXIST == errno ? 0 : -1;
+
+fail:
+    free(pathname);
+    free(parent);
+    return -1;
+}

--- a/src/include/mkdirp/mkdirp.c
+++ b/src/include/mkdirp/mkdirp.c
@@ -1,3 +1,28 @@
+/*
+ (The MIT License)
+
+Copyright (c) 2013 Stephen Mathieson &lt;me@stephenmathieson.com&gt;
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 #include <unistd.h>
 #include <errno.h>
 #include <stdlib.h>

--- a/src/include/mkdirp/mkdirp.h
+++ b/src/include/mkdirp/mkdirp.h
@@ -1,0 +1,9 @@
+#ifndef MKDIRP_H
+#define MKDIRP_H
+
+#include <sys/types.h>
+#include <sys/stat.h>
+
+int mkdirp(const char *, mode_t);
+
+#endif // MKDIRP_H

--- a/src/include/mkdirp/mkdirp.h
+++ b/src/include/mkdirp/mkdirp.h
@@ -1,9 +1,21 @@
-#ifndef MKDIRP_H
-#define MKDIRP_H
+
+//
+// mkdirp.h
+//
+// Copyright (c) 2013 Stephen Mathieson
+// MIT licensed
+//
+
+#ifndef MKDIRP
+#define MKDIRP
 
 #include <sys/types.h>
 #include <sys/stat.h>
 
-int mkdirp(const char *, mode_t);
+/*
+ * Recursively `mkdir(path, mode)`
+ */
 
-#endif // MKDIRP_H
+int mkdirp(const char *, mode_t );
+
+#endif

--- a/src/include/mkdirp/mkdirp.h
+++ b/src/include/mkdirp/mkdirp.h
@@ -1,10 +1,27 @@
+ /*
+ (The MIT License)
 
-//
-// mkdirp.h
-//
-// Copyright (c) 2013 Stephen Mathieson
-// MIT licensed
-//
+Copyright (c) 2013 Stephen Mathieson &lt;me@stephenmathieson.com&gt;
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 
 #ifndef MKDIRP
 #define MKDIRP

--- a/src/io.c
+++ b/src/io.c
@@ -77,6 +77,26 @@ BASEPATH_free(void) {
   }
 }
 
+char* resolvePath(char* partialPath, bool* shouldFree) {
+    const char* fullPath;
+    if (partialPath[0] != '/') {
+      char* base = BASEPATH_get();
+      fullPath = malloc(strlen(base)+strlen(partialPath)+1);
+      strcpy((char*)fullPath, base);
+      strcat((char*)fullPath, partialPath);
+      if (shouldFree != NULL) {
+        *shouldFree = true;
+      }
+    } else {
+      fullPath = partialPath;
+      if (shouldFree != NULL) {
+        *shouldFree = false;
+      }
+    }
+
+    return fullPath;
+}
+
 internal inline bool
 isDirectory(const char *path) {
    struct stat statbuf;

--- a/src/main.c
+++ b/src/main.c
@@ -38,6 +38,9 @@
 #include <microtar/microtar.h>
 #include <microtar/microtar.c>
 
+#include <mkdirp/mkdirp.h>
+#include <mkdirp/mkdirp.c>
+
 // Set up STB_IMAGE
 #define STBI_FAILURE_USERMSG
 #define STBI_NO_STDIO

--- a/src/modules/io.c
+++ b/src/modules/io.c
@@ -313,7 +313,7 @@ internal void
 FILESYSTEM_createDirectory(WrenVM *vm) {
   const char* path = wrenGetSlotString(vm, 1);
   const char* fullPath;
-  mode_t mode = 0700;
+  mode_t mode = 0777;
   if (path[0] != '/') {
     char* base = BASEPATH_get();
     fullPath = malloc(strlen(base)+strlen(path)+1);

--- a/src/modules/io.c
+++ b/src/modules/io.c
@@ -308,3 +308,25 @@ internal void
 FILESYSTEM_getBasePath(WrenVM* vm) {
   wrenSetSlotString(vm, 0, BASEPATH_get());
 }
+
+internal void
+FILESYSTEM_createDirectory(WrenVM *vm) {
+  const char* path = wrenGetSlotString(vm, 1);
+  const char* fullPath;
+  mode_t mode = 0700;
+  if (path[0] != '/') {
+    char* base = BASEPATH_get();
+    fullPath = malloc(strlen(base)+strlen(path)+1);
+    strcpy((char*)fullPath, base);
+    strcat((char*)fullPath, path);
+  } else {
+    fullPath = path;
+  }
+  int result = mkdirp(fullPath, mode);
+  if (path[0] != '/') {
+    free((void*)fullPath);
+  }
+  if (result == -1) {
+    VM_ABORT(vm, "Directory could not be created");
+  }
+}

--- a/src/modules/io.c
+++ b/src/modules/io.c
@@ -214,18 +214,11 @@ FILESYSTEM_loadEventComplete(SDL_Event* event) {
 internal void
 FILESYSTEM_listFiles(WrenVM* vm) {
   const char* path = wrenGetSlotString(vm, 1);
-  const char* fullPath;
-  if (path[0] != '/') {
-    char* base = BASEPATH_get();
-    fullPath = malloc(strlen(base)+strlen(path)+1);
-    strcpy((char*)fullPath, base); /* copy name into the new var */
-    strcat((char*)fullPath, path); /* add the extension */
-  } else {
-    fullPath = path;
-  }
+  bool shouldFree;
+  const char* fullPath = resolvePath(path, &shouldFree);
   tinydir_dir dir;
   int result = tinydir_open(&dir, fullPath);
-  if (path[0] != '/') {
+  if (shouldFree) {
     free((void*)fullPath);
   }
   if (result == -1) {
@@ -253,18 +246,11 @@ FILESYSTEM_listFiles(WrenVM* vm) {
 internal void
 FILESYSTEM_listDirectories(WrenVM* vm) {
   const char* path = wrenGetSlotString(vm, 1);
-  const char* fullPath;
-  if (path[0] != '/') {
-    char* base = BASEPATH_get();
-    fullPath = malloc(strlen(base)+strlen(path)+1);
-    strcpy((char*)fullPath, base); /* copy name into the new var */
-    strcat((char*)fullPath, path); /* add the extension */
-  } else {
-    fullPath = path;
-  }
+  bool shouldFree;
+  const char* fullPath = resolvePath(path, &shouldFree);
   tinydir_dir dir;
   int result = tinydir_open(&dir, fullPath);
-  if (path[0] != '/') {
+  if (shouldFree) {
     free((void*)fullPath);
   }
   if (result == -1) {
@@ -312,18 +298,12 @@ FILESYSTEM_getBasePath(WrenVM* vm) {
 internal void
 FILESYSTEM_createDirectory(WrenVM *vm) {
   const char* path = wrenGetSlotString(vm, 1);
-  const char* fullPath;
   mode_t mode = 0777;
-  if (path[0] != '/') {
-    char* base = BASEPATH_get();
-    fullPath = malloc(strlen(base)+strlen(path)+1);
-    strcpy((char*)fullPath, base);
-    strcat((char*)fullPath, path);
-  } else {
-    fullPath = path;
-  }
+
+  bool shouldFree;
+  const char* fullPath = resolvePath(path, &shouldFree);
   int result = mkdirp(fullPath, mode);
-  if (path[0] != '/') {
+  if (shouldFree) {
     free((void*)fullPath);
   }
   if (result == -1) {

--- a/src/modules/io.wren
+++ b/src/modules/io.wren
@@ -13,6 +13,7 @@ class FileSystem {
   foreign static save(path, buffer)
   foreign static prefPath(org, app)
   foreign static basePath()
+  foreign static createDirectory(path)
 
   // @Unstable - DO NOT USE
   foreign static f_load(path, op)

--- a/src/vm.c
+++ b/src/vm.c
@@ -287,6 +287,7 @@ internal WrenVM* VM_create(ENGINE* engine) {
   MAP_addFunction(&engine->moduleMap, "io", "static FileSystem.listDirectories(_)", FILESYSTEM_listDirectories);
   MAP_addFunction(&engine->moduleMap, "io", "static FileSystem.prefPath(_,_)", FILESYSTEM_getPrefPath);
   MAP_addFunction(&engine->moduleMap, "io", "static FileSystem.basePath()", FILESYSTEM_getBasePath);
+  MAP_addFunction(&engine->moduleMap, "io", "static FileSystem.createDirectory(_)", FILESYSTEM_createDirectory);
 
 
   // Buffer


### PR DESCRIPTION
Simulates `mkdir -p` and aborts if directory couldn't be created. Testing done on linux (Ubuntu 18.04). Windows tests are needed.

Fixes #102 

Uses code from [mkdirp](https://github.com/stephenmathieson/mkdirp.c)

Example usage:
```
import "io" for FileSystem
FileSystem.createDirectory("test/me/out")
```
The permissions given to the directory are hard coded to `0777` as of now which should be changed if required.

Do let me know of any changes!