### PR TITLE
Process Arguments

### DIFF
--- a/docs/modules/dome.md
+++ b/docs/modules/dome.md
@@ -13,8 +13,10 @@ It contains the following classes:
 ## Process
 
 ### Static Fields
-#### `static arguments: String[]`
-Returns a string list of all command line arguments used to invoke DOME's execution, in the other they were provided.
+#### `static args: String[]`
+Returns a string list of all non-option command line arguments used to invoke DOME's execution. The first two elements of the returned list will be:
+1) the path and name of DOME's invokation.
+2) The entry path, combined with the evaluated basepath.
 
 ### Static Methods
 

--- a/docs/modules/dome.md
+++ b/docs/modules/dome.md
@@ -12,6 +12,10 @@ It contains the following classes:
 
 ## Process
 
+### Static Fields
+#### `static arguments: String[]`
+Returns a string list of all command line arguments used to invoke DOME's execution, in the other they were provided.
+
 ### Static Methods
 
 #### `static exit(): Void`

--- a/docs/modules/dome.md
+++ b/docs/modules/dome.md
@@ -15,8 +15,9 @@ It contains the following classes:
 ### Static Fields
 #### `static args: String[]`
 Returns a string list of all non-option command line arguments used to invoke DOME's execution. The first two elements of the returned list will be:
-1) the path and name of DOME's invokation.
-2) The entry path, combined with the evaluated basepath.
+
+1. the path and name of DOME's invokation.
+2. The entry path, combined with the evaluated basepath.
 
 ### Static Methods
 

--- a/src/engine.c
+++ b/src/engine.c
@@ -330,6 +330,7 @@ ENGINE_free(ENGINE* engine) {
   }
 
   if (engine->argv != NULL) {
+    free(engine->argv[1]);
     free(engine->argv);
   }
 

--- a/src/engine.c
+++ b/src/engine.c
@@ -317,10 +317,6 @@ ENGINE_free(ENGINE* engine) {
     free(engine->pixels);
   }
 
-  if (engine->argv != NULL) {
-    free(engine->argv);
-  }
-
   if (engine->texture != NULL) {
     SDL_DestroyTexture(engine->texture);
   }
@@ -331,6 +327,10 @@ ENGINE_free(ENGINE* engine) {
 
   if (engine->window != NULL) {
     SDL_DestroyWindow(engine->window);
+  }
+
+  if (engine->argv != NULL) {
+    free(engine->argv);
   }
 
   // DEBUG features

--- a/src/engine.c
+++ b/src/engine.c
@@ -212,6 +212,9 @@ ENGINE_init(ENGINE* engine) {
   engine->width = GAME_WIDTH;
   engine->height = GAME_HEIGHT;
 
+  engine->argv = NULL;
+  engine->argc = 0;
+
   return engine;
 }
 
@@ -312,6 +315,10 @@ ENGINE_free(ENGINE* engine) {
 
   if (engine->pixels != NULL) {
     free(engine->pixels);
+  }
+
+  if (engine->argv != NULL) {
+    free(engine->argv);
   }
 
   if (engine->texture != NULL) {

--- a/src/engine.h
+++ b/src/engine.h
@@ -42,6 +42,8 @@ typedef struct {
   int32_t offsetY;
   mtar_t* tar;
   bool running;
+  char** argv;
+  size_t argc;
   bool lockstep;
   bool mouseRelative;
   int mouseX;

--- a/src/main.c
+++ b/src/main.c
@@ -156,7 +156,7 @@ printUsage(ENGINE* engine) {
   ENGINE_printLog(engine, "\nUsage: \n");
 
   ENGINE_printLog(engine, "  dome [options]\n");
-  ENGINE_printLog(engine, "  dome [options] [--] [entry path] [arguments]\n");
+  ENGINE_printLog(engine, "  dome [options] [--] entry_path [arguments]\n");
   ENGINE_printLog(engine, "  dome -h | --help\n");
   ENGINE_printLog(engine, "  dome -v | --version\n");
   ENGINE_printLog(engine, "\nOptions: \n");

--- a/src/main.c
+++ b/src/main.c
@@ -179,6 +179,11 @@ int main(int argc, char* args[])
   engine.record.makeGif = false;
 
   ENGINE_init(&engine);
+  engine.argv = calloc(sizeof(char*), argc);
+  engine.argc = argc;
+  for (int i = 0; i < argc; i++) {
+    engine.argv[i] = args[i];
+  }
 
   // TODO: Use getopt to parse the arguments better
   struct optparse_long longopts[] = {
@@ -187,6 +192,7 @@ int main(int argc, char* args[])
     {"console", 'c', OPTPARSE_NONE},
     #endif
     {"debug", 'd', OPTPARSE_NONE},
+    {"path", 'p', OPTPARSE_REQUIRED},
     {"help", 'h', OPTPARSE_NONE},
     {"version", 'v', OPTPARSE_NONE},
     {"record", 'r', OPTPARSE_OPTIONAL},
@@ -195,6 +201,7 @@ int main(int argc, char* args[])
   };
   // char *arg;
   int option;
+  char* arg = NULL;
   struct optparse options;
   optparse_init(&options, args);
   while ((option = optparse_long(&options, longopts, NULL)) != -1) {
@@ -246,6 +253,9 @@ int main(int argc, char* args[])
         printTitle(&engine);
         printVersion(&engine);
         goto cleanup;
+      case 'p':
+        arg = options.optarg;
+        break;
       case '?':
         fprintf(stderr, "%s: %s\n", args[0], options.errmsg);
         result = EXIT_FAILURE;
@@ -258,7 +268,7 @@ int main(int argc, char* args[])
     char* mainFileName = "main.wren";
 
     char* base = BASEPATH_get();
-    char* arg = optparse_arg(&options);
+    arg = arg ? arg : optparse_arg(&options);
 
     char pathBuf[PATH_MAX];
 

--- a/src/main.c
+++ b/src/main.c
@@ -182,11 +182,6 @@ int main(int argc, char* args[])
   engine.record.makeGif = false;
 
   ENGINE_init(&engine);
-  engine.argv = calloc(sizeof(char*), argc);
-  engine.argc = argc;
-  for (int i = 0; i < argc; i++) {
-    engine.argv[i] = args[i];
-  }
 
   // TODO: Use getopt to parse the arguments better
   struct optparse_long longopts[] = {
@@ -269,14 +264,21 @@ int main(int argc, char* args[])
 
     char pathBuf[PATH_MAX];
     char* fileName = NULL;
-    printf("%i\n", argc);
-    char* arg = optparse_arg(&options);
-    int domeArgs = arg == NULL ? 0 : 1;
+
+    // Get non-option args list
+    engine.argv = calloc(argc, sizeof(char*));
+    engine.argv[0] = args[0];
+    int domeArgCount = 1;
     char* otherArg = NULL;
     while ((otherArg = optparse_arg(&options))) {
-      domeArgs++;
+      engine.argv[domeArgCount] = otherArg;
+      domeArgCount++;
     }
-    bool autoResolve = (domeArgs == 0);
+
+    engine.argv = realloc(engine.argv, sizeof(char*) * domeArgCount);
+    engine.argc = domeArgCount;
+    char* arg = engine.argv[1];
+    bool autoResolve = (domeArgCount == 0);
 
     // Get establish the path components: filename(?) and basepath.
     if (arg != NULL) {

--- a/src/main.c
+++ b/src/main.c
@@ -154,7 +154,7 @@ printVersion(ENGINE* engine) {
 internal void
 printUsage(ENGINE* engine) {
   ENGINE_printLog(engine, "\nUsage: \n");
-  ENGINE_printLog(engine, "  dome [-c] [-d | --debug] [-r<gif> | --record=<gif>] [-b<buf> | --buffer=<buf>] [entry path]\n");
+  ENGINE_printLog(engine, "  dome [-b<buf> | --buffer=<buf>] [-c] [-d | --debug] [-p<path> | --path=<entry path>] [-r<gif> | --record=<gif>] [entry path]\n");
   ENGINE_printLog(engine, "  dome -h | --help\n");
   ENGINE_printLog(engine, "  dome -v | --version\n");
   ENGINE_printLog(engine, "\nOptions: \n");
@@ -164,8 +164,9 @@ printUsage(ENGINE* engine) {
 #endif
   ENGINE_printLog(engine, "  -d --debug          Enables debug mode.\n");
   ENGINE_printLog(engine, "  -h --help           Show this screen.\n");
-  ENGINE_printLog(engine, "  -v --version        Show version.\n");
+  ENGINE_printLog(engine, "  -p --path           The path to your application entry point.\n");
   ENGINE_printLog(engine, "  -r --record=<gif>   Record video to <gif>.\n");
+  ENGINE_printLog(engine, "  -v --version        Show version.\n");
 }
 
 int main(int argc, char* args[])

--- a/src/main.c
+++ b/src/main.c
@@ -275,6 +275,7 @@ int main(int argc, char* args[])
 
     char* fileName = NULL;
 
+    // Get base directory
     if (arg != NULL) {
       strcpy(pathBuf, base);
       strcat(pathBuf, arg);
@@ -283,6 +284,7 @@ int main(int argc, char* args[])
       } else {
         char* dirc = strdup(pathBuf);
         char* basec = strdup(pathBuf);
+        // This sets the filename used.
         fileName = basename(dirc);
         BASEPATH_set(dirname(basec));
         free(dirc);
@@ -292,26 +294,32 @@ int main(int argc, char* args[])
       base = BASEPATH_get();
     }
 
+    // If a filename is given in the path, use it, or assume its 'game.egg'
     strcpy(pathBuf, base);
     strcat(pathBuf, fileName ? fileName : defaultEggName);
 
     if (doesFileExist(pathBuf)) {
+      // the current path exists, let's see if it's a TAR file.
       engine.tar = malloc(sizeof(mtar_t));
       int tarResult = mtar_open(engine.tar, pathBuf, "r");
       if (tarResult == MTAR_ESUCCESS) {
         ENGINE_printLog(&engine, "Loading bundle %s\n", pathBuf);
       } else {
+        // Not a valid tar file.
         free(engine.tar);
         engine.tar = NULL;
       }
     }
 
     if (engine.tar != NULL) {
+      // It is a tar file, we need to look for a "main.wren" entry point.
       strcpy(pathBuf, mainFileName);
     } else {
+      // Not a tar file, use the given path or main.wren
       strcpy(pathBuf, fileName ? fileName : mainFileName);
     }
 
+    // The basepath is incorporated later, so we pass the basename version to this method.
     gameFile = ENGINE_readFile(&engine, pathBuf, &gameFileLength);
     if (gameFile == NULL) {
       if (engine.tar != NULL) {

--- a/src/modules/color.wren
+++ b/src/modules/color.wren
@@ -1,14 +1,10 @@
 import "math" for HexToNum, NumToHex
+
 var SubStr = Fn.new {|str, start, len|
   return str.bytes.skip(start).take(len).toList
 }
 
-/**
-    @Class Color
-      An instance of this class represents an rgb color, which can be passed to Canvas methods.
-*/
 class Color {
-
   construct hex(hex) {
     if (hex is String) {
       var offset = 0

--- a/src/modules/dome.c
+++ b/src/modules/dome.c
@@ -9,6 +9,19 @@ PROCESS_exit(WrenVM* vm) {
 }
 
 internal void
+PROCESS_getArguments(WrenVM* vm) {
+  ENGINE* engine = (ENGINE*)wrenGetUserData(vm);
+  size_t count = engine->argc;
+  char** arguments = engine->argv;
+  wrenEnsureSlots(vm, 2);
+  wrenSetSlotNewList(vm, 0);
+  for (size_t i = 0; i < count; i++) {
+    wrenSetSlotString(vm, 1, arguments[i]);
+    wrenInsertInList(vm, 0, i, 1);
+  }
+}
+
+internal void
 STRING_UTILS_toLowercase(WrenVM* vm) {
   ASSERT_SLOT_TYPE(vm, 1, STRING, "string");
   int length;

--- a/src/modules/dome.wren
+++ b/src/modules/dome.wren
@@ -44,6 +44,7 @@ class Version {
 
 
 class Process {
+  foreign static arguments
   foreign static f_exit(n)
   static exit(n) {
     f_exit(n)

--- a/src/modules/dome.wren
+++ b/src/modules/dome.wren
@@ -44,7 +44,7 @@ class Version {
 
 
 class Process {
-  foreign static arguments
+  foreign static args
   foreign static f_exit(n)
   static exit(n) {
     f_exit(n)

--- a/src/modules/graphics.wren
+++ b/src/modules/graphics.wren
@@ -1,13 +1,3 @@
-/**
-
-  @Module graphics
-  The graphics module provides all the system functions required for drawing to the screen.
-*/
-
-/**
-    @Class Canvas
-      This class provides static methods for drawing primitives and images.
-*/
 class Canvas {
   static init_() {
     __defaultFont = null
@@ -66,22 +56,6 @@ class Canvas {
   foreign static f_ellipse(x1, y1, x2, y2, c)
   foreign static f_ellipsefill(x1, y1, x2, y2, c)
 
- /**
-     @Method pset
-       Sets the given (x, y) co-ordinate with the Color given.
-       @Param
-         @Name x
-         @Type number
-         The x-coordinate of the pixel to set.
-       @Param
-         @Name y
-         @Type number
-         The y-coordinate of the pixel to set.
-       @Param
-         @Name y
-         @Type Color | number
-         The 32-bit value or Color object representing the color the pixel should be set to.
- */
   static pset(x, y, c) {
     if (c is Color) {
       f_pset(x, y, c.toNum)
@@ -186,9 +160,9 @@ class Canvas {
 
 
 // These need to be at the bottom to prevent cyclic dependancy
+import "color" for Color
 import "image" for Drawable, ImageData
 import "vector" for Point, Vec, Vector
 import "font" for Font, RasterizedFont
-import "color" for Color
 
 Canvas.init_()

--- a/src/modules/image.wren
+++ b/src/modules/image.wren
@@ -1,4 +1,3 @@
-import "color" for Color
 class Drawable {
   draw(x, y) {}
 }
@@ -7,7 +6,6 @@ foreign class DrawCommand is Drawable {
   construct new(image, params) {}
 
   static parse(image, map) {
-    import "graphics" for Color
     var list = [
       map["angle"] || 0,
       map["scaleX"] || 1,
@@ -39,7 +37,6 @@ foreign class ImageData is Drawable {
 
   foreign f_getPNG()
   saveToFile(path) {
-    import "io" for FileSystem
     var data = f_getPNG()
     if (data != null) {
       FileSystem.save(path, data)
@@ -69,7 +66,6 @@ foreign class ImageData is Drawable {
     }
 
     if (!__cache.containsKey(path)) {
-      import "io" for FileSystem
       var data = FileSystem.load(path)
       __cache[path] = ImageData.initFromFile(data)
     }
@@ -113,3 +109,5 @@ foreign class ImageData is Drawable {
   }
 }
 
+import "color" for Color
+import "io" for FileSystem

--- a/src/vm.c
+++ b/src/vm.c
@@ -186,7 +186,7 @@ internal WrenVM* VM_create(ENGINE* engine) {
   // DOME
   MAP_addFunction(&engine->moduleMap, "dome", "static StringUtils.toLowercase(_)", STRING_UTILS_toLowercase);
   MAP_addFunction(&engine->moduleMap, "dome", "static Process.f_exit(_)", PROCESS_exit);
-  MAP_addFunction(&engine->moduleMap, "dome", "static Process.arguments", PROCESS_getArguments);
+  MAP_addFunction(&engine->moduleMap, "dome", "static Process.args", PROCESS_getArguments);
   MAP_addFunction(&engine->moduleMap, "dome", "static Window.resize(_,_)", WINDOW_resize);
   MAP_addFunction(&engine->moduleMap, "dome", "static Window.title=(_)", WINDOW_setTitle);
   MAP_addFunction(&engine->moduleMap, "dome", "static Window.vsync=(_)", WINDOW_setVsync);

--- a/src/vm.c
+++ b/src/vm.c
@@ -186,6 +186,7 @@ internal WrenVM* VM_create(ENGINE* engine) {
   // DOME
   MAP_addFunction(&engine->moduleMap, "dome", "static StringUtils.toLowercase(_)", STRING_UTILS_toLowercase);
   MAP_addFunction(&engine->moduleMap, "dome", "static Process.f_exit(_)", PROCESS_exit);
+  MAP_addFunction(&engine->moduleMap, "dome", "static Process.arguments", PROCESS_getArguments);
   MAP_addFunction(&engine->moduleMap, "dome", "static Window.resize(_,_)", WINDOW_resize);
   MAP_addFunction(&engine->moduleMap, "dome", "static Window.title=(_)", WINDOW_setTitle);
   MAP_addFunction(&engine->moduleMap, "dome", "static Window.vsync=(_)", WINDOW_setVsync);

--- a/src/vm.c
+++ b/src/vm.c
@@ -5,7 +5,7 @@ VM_bind_foreign_class(WrenVM* vm, const char* module, const char* className) {
   methods.allocate = NULL;
   methods.finalize = NULL;
 
-  
+
   if (STRINGS_EQUAL(module, "image")) {
     if (STRINGS_EQUAL(className, "ImageData")) {
       methods.allocate = IMAGE_allocate;


### PR DESCRIPTION
This is my take on #87 and #89 , inspired by how NodeJS handles its commandline parameters.

The resulting usage now looks like this:
```
Usage:
  dome [options]
  dome [options] [--] entry_path [arguments]
  dome -h | --help
  dome -v | --version
```
The first case, where no arguments are provided, will follow the established auto-resolution procedure:
1) Is there `game.egg` in the current working directory? if so, execute it
2) Is there `main.wren` in the current working directory? if so, execute it.
3) Print an error, since no entry point could be found.

For the second case, where an entry path (the first non-option argument) and some number of arguments are provided, will do the following:
1) Is the entry path a directory? If so, follow the auto-resolution as described above, using that directory.
2) Else, use the entry path:
2a) Test whether it is an .egg file, and use it if it is.
2b) Otherwise, treat it as a .wren file, and process accordingly.

`Process.args` will return all non-option arguments used to invoke DOME, but it will always include the invoked executable path and the full path of the entry point (by using the basepath).


(Closes #87 and Closes #89 )